### PR TITLE
enhance(Button): add button icon group component

### DIFF
--- a/src/Button.stories.tsx
+++ b/src/Button.stories.tsx
@@ -1,4 +1,10 @@
-import React from 'react'
+import {
+  faHouse,
+  faPlaneArrival,
+  faPlaneDeparture,
+} from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import React, { useState } from 'react'
 import Button from './Button'
 
 const ExampleIcon = (
@@ -52,3 +58,15 @@ export const ColorButton = () => (
     onClick={() => alert('Red button was pressed!')}
   />
 )
+
+export const ButtonIconGroup = () => {
+  const [state, setState] = useState<number | undefined>(undefined)
+
+  return (
+    <Button.IconGroup state={state} setState={setState}>
+      <FontAwesomeIcon icon={faPlaneArrival} />
+      <FontAwesomeIcon icon={faPlaneDeparture} />
+      <FontAwesomeIcon icon={faHouse} />
+    </Button.IconGroup>
+  )
+}

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { Dispatch, useContext } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { ThemeContext } from './ThemeProvider'
 
@@ -130,6 +130,57 @@ Button.Label = function ButtonLabel({
   children: React.ReactNode
 }) {
   return <div className={twMerge('', className?.root)}>{children}</div>
+}
+
+export interface ButtonIconGroupProps {
+  state: number | undefined
+  setState: Dispatch<React.SetStateAction<number | undefined>>
+  className?: {
+    root?: string
+    children?: string
+  }
+  children: React.ReactNode[]
+}
+
+Button.IconGroup = function ButtonIconGroup({
+  state,
+  setState,
+  className,
+  children,
+}: ButtonIconGroupProps) {
+  const theme = useContext(ThemeContext)
+
+  return (
+    <div
+      className={twMerge(
+        'flex flex-row justify-between border border-solid w-max rounded',
+        theme.primaryBorder,
+        className?.root
+      )}
+    >
+      {children.map((child, index) => {
+        return (
+          <Button
+            key={index}
+            className={{
+              root: twMerge(
+                'p-1.5 first:rounded-l-sm last:rounded-r-sm',
+                theme.primaryBgHover,
+                state === index
+                  ? `${theme.primaryBgDark} text-white hover:bg-unset`
+                  : 'bg-white',
+                className?.children
+              ),
+            }}
+            onClick={() => setState(index)}
+            basic
+          >
+            {child}
+          </Button>
+        )
+      })}
+    </div>
+  )
 }
 
 export default Button


### PR DESCRIPTION
This pull requests adds a button group wrapper component, which allows to display icon buttons next to each other and displays the active one. State management is left to the user.