### PR TITLE
enhance(Dropdown): extend styling possibilities and active states

### DIFF
--- a/src/Dropdown.stories.tsx
+++ b/src/Dropdown.stories.tsx
@@ -191,3 +191,33 @@ export const CustomLabel = () => {
     </div>
   )
 }
+
+export const Active = () => {
+  return (
+    <div>
+      <div>
+        One possibility to highlight active elements is through the "selected"
+        prop on the item itself. To make the dropdown component keep the correct
+        state, a list of strings, so-called "activeItems" can be passed, which
+        are then compared to the label values. If the label is given as a React
+        node, the active value will not be considered.
+      </div>
+      <Dropdown
+        trigger="Test"
+        activeItems={['Element 1 long', 'Element 3 short']}
+        items={[
+          {
+            label: 'Element 1 long',
+            onClick: () => alert('Element 1 clicked'),
+          },
+          { label: 'Element 2', onClick: () => alert('Element 2 clicked') },
+          {
+            label: 'Element 3 short',
+            onClick: () => alert('Element 3 clicked'),
+          },
+          { label: 'Element 4', onClick: () => alert('Element 4 clicked') },
+        ]}
+      />
+    </div>
+  )
+}

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -109,7 +109,12 @@ export function Dropdown({
           )}
           onClick={onClick}
         >
-          <div className={twMerge('flex-1', selected && 'font-bold')}>
+          <div
+            className={twMerge(
+              'flex-1',
+              selected && twMerge('font-bold', className?.active)
+            )}
+          >
             {label}
           </div>
           {shorting && <div className="ml-6">{shorting}</div>}

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -23,12 +23,14 @@ interface DropdownProps {
   }
   trigger: string | React.ReactNode
   items?: Item[]
+  activeItems?: string[]
   groups?: Item[][]
   className?: {
     trigger?: string
     triggerDisabled?: string
     viewport?: string
     item?: string
+    activeItem?: string
     group?: string
     arrow?: string
   }
@@ -51,6 +53,7 @@ export interface DropdownWithGroupsProps extends DropdownProps {
  * @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy)
  * @param trigger - The content of the trigger button or a custom trigger component to replace the default button.
  * @param items - The items that are displayed in the dropdown menu. This attribute should not be set, if groups are used.
+ * @param activeItems - List of labels that should be considered active. This attribute has a similar function as the "select" attribute on the item props and should not be used at the same time.
  * @param groups - The groups of items that are displayed in the dropdown menu. This attribute should not be set, if items are used.
  * @param className - The optional className object allows you to override the default styling.
  * @param disabled - Indicate whether the dropdown is disabled or not. Conditional styling is applied, if this is true.
@@ -61,6 +64,7 @@ export function Dropdown({
   data,
   trigger,
   items,
+  activeItems,
   groups,
   className,
   disabled = false,
@@ -71,6 +75,7 @@ export function Dropdown({
     id,
     data,
     label,
+    active = false,
     onClick,
     shorting,
     selected,
@@ -82,10 +87,14 @@ export function Dropdown({
       test?: string
     }
     label: string | React.ReactNode
+    active?: boolean
     onClick: () => void
     shorting?: string
     selected?: boolean
-    className?: string
+    className?: {
+      root?: string
+      active?: string
+    }
   }) => {
     if (typeof label === 'string') {
       return (
@@ -95,7 +104,8 @@ export function Dropdown({
           data-test={data?.test}
           className={twMerge(
             `hover:${theme.primaryBgMedium} sm:hover:!text-white px-2 py-0.5 hover:cursor-pointer rounded flex flex-row`,
-            className
+            active && twMerge('font-bold', className?.active),
+            className?.root
           )}
           onClick={onClick}
         >
@@ -112,7 +122,7 @@ export function Dropdown({
         data-cy={data?.cy}
         data-test={data?.test}
         onClick={onClick}
-        className={twMerge('rounded-md', className)}
+        className={twMerge('rounded-md', className?.root)}
       >
         {label}
       </RadixDropdown.Item>
@@ -171,7 +181,14 @@ export function Dropdown({
                 onClick={item.onClick}
                 shorting={item.shorting}
                 selected={item.selected}
-                className={className?.item}
+                active={
+                  typeof item.label === 'string' &&
+                  activeItems?.includes(item.label)
+                }
+                className={{
+                  root: className?.item,
+                  active: className?.activeItem,
+                }}
               />
             ))}
           </div>
@@ -190,7 +207,10 @@ export function Dropdown({
                     label={item.label}
                     onClick={item.onClick}
                     shorting={item.shorting}
-                    className={className?.item}
+                    className={{
+                      root: className?.item,
+                      active: className?.activeItem,
+                    }}
                   />
                 ))}
               </RadixDropdown.Group>

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -30,6 +30,7 @@ interface DropdownProps {
     viewport?: string
     item?: string
     group?: string
+    arrow?: string
   }
   disabled?: boolean
 }
@@ -158,7 +159,7 @@ export function Dropdown({
         )}
       >
         <RadixDropdown.Arrow
-          className={twMerge(theme.primaryFill, 'opacity-25')}
+          className={twMerge(theme.primaryFill, 'opacity-25', className?.arrow)}
         />
 
         {items && (


### PR DESCRIPTION
This pull request adds the following minor enhancements:
- The dropdown viewport arrow is now stylable
- An additional list of strings "activeItems" can be passed to the dropdown component, whose content will then be compared to the label values (if they are strings) and conditional styling is applied ("deduce selected style inside of the compontent")
- The same styling className prop will now also be applied to items with "select" prop set to true