### PR TITLE
chore(repo): ignore agent stack worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 dist/
 .turbo/
+trees/
 
 .DS_Store
 .vercel/


### PR DESCRIPTION
## Summary

- Ignore agent-created stack worktrees under trees/.
- Establish the repository prerequisite for the approved v5 stacked-work plan.

## Verification

- git check-ignore -v trees/v5-api-contracts
- No runtime or package code changed.

## Scope

This is a standalone hygiene prerequisite. It does not alter PR #184 and should land before Stack A worktrees are created.