### PR TITLE
feat(refs): expose v5 direct-control refs

### DIFF
--- a/packages/design-system/MIGRATION.md
+++ b/packages/design-system/MIGRATION.md
@@ -206,6 +206,25 @@ component from `@uzh-bf/design-system/primitives` instead of adding an
 unsupported prop to the custom composite. Move application-specific workflow
 metadata outside the step object or model it in the owning application state.
 
+### Direct-control refs
+
+The v5 direct-control components use React 19's normal `ref` prop to expose the
+visible interactive element. The ref target is intentionally concrete:
+
+| Component                     | Ref target                          |
+| ----------------------------- | ----------------------------------- |
+| `Button` (native-button path) | `HTMLButtonElement`                 |
+| `TextField`                   | `HTMLInputElement`                  |
+| `NumberField`                 | `HTMLInputElement`                  |
+| `TextareaField`               | `HTMLTextAreaElement`               |
+| `Select`                      | visible trigger `HTMLButtonElement` |
+| `Combobox`                    | visible trigger `HTMLButtonElement` |
+
+Use `ref`, not a parallel `forwardedRef` prop. `Button` rejects `ref` when
+`asChild` is `true` because the child may not be a button; polymorphic child
+refs remain a follow-up. Composite refs for deprecated Formik wrappers, OTP,
+date/color pickers, and `Table` are not part of this direct-control migration.
+
 v5 also marks the package `"sideEffects": ["*.css"]` so consuming bundlers can
 tree-shake unused components while preserving the required stylesheet import — no
 action needed.

--- a/packages/design-system/MIGRATION.md
+++ b/packages/design-system/MIGRATION.md
@@ -225,6 +225,14 @@ Use `ref`, not a parallel `forwardedRef` prop. `Button` rejects `ref` when
 refs remain a follow-up. Composite refs for deprecated Formik wrappers, OTP,
 date/color pickers, and `Table` are not part of this direct-control migration.
 
+`ButtonProps` is now a discriminated union so the native-button ref target can
+remain sound. If a wrapper previously used `interface ... extends ButtonProps`,
+define the wrapper props as an intersection instead:
+
+```ts
+type WrappedButtonProps = ButtonProps & { analyticsId?: string }
+```
+
 v5 also marks the package `"sideEffects": ["*.css"]` so consuming bundlers can
 tree-shake unused components while preserving the required stylesheet import — no
 action needed.

--- a/packages/design-system/src/Button.tsx
+++ b/packages/design-system/src/Button.tsx
@@ -8,24 +8,22 @@ import { Button as ShadcnButton } from './ui/button'
 
 type ButtonPrimitiveProps = ComponentPropsWithoutRef<typeof ShadcnButton>
 
-export interface ButtonProps
-  extends Omit<
-    ButtonPrimitiveProps,
-    | 'asChild'
-    | 'aria-busy'
-    | 'children'
-    | 'className'
-    | 'disabled'
-    | 'onClick'
-    | 'size'
-    | 'type'
-    | 'variant'
-  > {
+type ButtonBaseProps = Omit<
+  ButtonPrimitiveProps,
+  | 'asChild'
+  | 'aria-busy'
+  | 'children'
+  | 'className'
+  | 'disabled'
+  | 'onClick'
+  | 'size'
+  | 'type'
+  | 'variant'
+> & {
   id?: string
   children?: React.ReactNode
   onClick?: (e?: React.MouseEvent<HTMLButtonElement>) => void
   disabled?: boolean
-  asChild?: boolean
   primary?: boolean
   destructive?: boolean
   active?: boolean
@@ -44,6 +42,16 @@ export interface ButtonProps
   }
 }
 
+export type ButtonProps =
+  | (ButtonBaseProps & {
+      asChild?: false
+      ref?: React.Ref<HTMLButtonElement>
+    })
+  | (ButtonBaseProps & {
+      asChild: true
+      ref?: never
+    })
+
 /**
  * This function returns a pre-styled Button component based on the custom theme.
  *
@@ -61,6 +69,7 @@ export interface ButtonProps
  * @param type - The html type of the button.
  * @param className - The optional className object allows you to override the default styling.
  * @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy)
+ * @param ref - A ref to the native button. Refs are not supported with `asChild` until a polymorphic child-target contract is defined.
  * @returns Button component
  */
 export function Button({
@@ -79,6 +88,7 @@ export function Button({
   type = 'button',
   className,
   data,
+  ref,
   ...props
 }: ButtonProps) {
   return (
@@ -95,6 +105,7 @@ export function Button({
       }
       size={size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : 'default'}
       disabled={disabled || loading}
+      ref={ref}
       // The loading spinner is decorative, so the busy state is only available
       // to assistive technology through aria-busy.
       aria-busy={loading || undefined}

--- a/packages/design-system/src/Combobox.tsx
+++ b/packages/design-system/src/Combobox.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Check, ChevronsUpDown } from 'lucide-react'
+import type { Ref } from 'react'
 import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 
@@ -46,6 +47,7 @@ export interface ComboboxProps {
     test?: string
   }
   className?: ComboboxClassName
+  ref?: Ref<HTMLButtonElement>
 }
 
 /**
@@ -64,6 +66,7 @@ export interface ComboboxProps {
  * @param ariaLabel - Optional accessible name for the trigger (use when the visible label is ambiguous).
  * @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy).
  * @param className - The optional className object allows you to override the default styling.
+ * @param ref - A ref to the visible trigger button.
  * @returns Combobox component
  */
 export function Combobox({
@@ -78,6 +81,7 @@ export function Combobox({
   ariaLabel,
   data,
   className,
+  ref,
 }: ComboboxProps) {
   const [open, setOpen] = useState(false)
 
@@ -92,6 +96,7 @@ export function Combobox({
       <PopoverTrigger asChild>
         <Button
           id={id}
+          ref={ref}
           type="button"
           variant="outline"
           aria-haspopup="listbox"

--- a/packages/design-system/src/DirectControlRefs.stories.mdx
+++ b/packages/design-system/src/DirectControlRefs.stories.mdx
@@ -6,6 +6,13 @@ import TextField from './forms/TextField'
 import TextareaField from './forms/TextareaField'
 import Select from './Select'
 
+{/* START README */}
+<div className="prose prose-sm max-w-none">
+This story demonstrates the direct-control ref contracts for buttons, form
+fields, Select, and Combobox, including focus actions for each target.
+</div>
+{/* END README */}
+
 {/*
   This story is a small consumer-facing contract harness. Every focus action
   uses the public ref prop, while Select and Combobox also keep their existing

--- a/packages/design-system/src/DirectControlRefs.stories.mdx
+++ b/packages/design-system/src/DirectControlRefs.stories.mdx
@@ -1,0 +1,141 @@
+import { useRef, useState } from 'react'
+import Button from './Button'
+import { Combobox } from './Combobox'
+import NumberField from './forms/NumberField'
+import TextField from './forms/TextField'
+import TextareaField from './forms/TextareaField'
+import Select from './Select'
+
+{/*
+  This story is a small consumer-facing contract harness. Every focus action
+  uses the public ref prop, while Select and Combobox also keep their existing
+  trigger and selection behavior under the same ref wiring.
+*/}
+
+export const Default = () => {
+  const fruits = [
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+  ]
+  const frameworks = [
+    { value: 'react', label: 'React' },
+    { value: 'vite', label: 'Vite' },
+  ]
+  const buttonRef = useRef(null)
+  const textFieldRef = useRef(null)
+  const numberFieldRef = useRef(null)
+  const textareaFieldRef = useRef(null)
+  const selectRef = useRef(null)
+  const comboboxRef = useRef(null)
+  const [textValue, setTextValue] = useState('')
+  const [numberValue, setNumberValue] = useState('1')
+  const [textareaValue, setTextareaValue] = useState('')
+  const [selectValue, setSelectValue] = useState('')
+  const [comboboxValue, setComboboxValue] = useState('')
+
+  return (
+    <div className="flex max-w-xl flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Button ref={buttonRef} data={{ test: 'ref-button' }}>
+          Ref button
+        </Button>
+        <button
+          type="button"
+          data-test="focus-button"
+          onClick={() => buttonRef.current?.focus()}
+        >
+          Focus button
+        </button>
+      </div>
+
+      <div className="flex items-end gap-2">
+        <TextField
+          label="Text field"
+          value={textValue}
+          onChange={setTextValue}
+          data={{ test: 'ref-text-field' }}
+          ref={textFieldRef}
+        />
+        <button
+          type="button"
+          data-test="focus-text-field"
+          onClick={() => textFieldRef.current?.focus()}
+        >
+          Focus text
+        </button>
+      </div>
+
+      <div className="flex items-end gap-2">
+        <NumberField
+          label="Number field"
+          value={numberValue}
+          onChange={setNumberValue}
+          data={{ test: 'ref-number-field' }}
+          ref={numberFieldRef}
+        />
+        <button
+          type="button"
+          data-test="focus-number-field"
+          onClick={() => numberFieldRef.current?.focus()}
+        >
+          Focus number
+        </button>
+      </div>
+
+      <div className="flex items-end gap-2">
+        <TextareaField
+          label="Textarea field"
+          value={textareaValue}
+          onChange={setTextareaValue}
+          data={{ test: 'ref-textarea-field' }}
+          ref={textareaFieldRef}
+        />
+        <button
+          type="button"
+          data-test="focus-textarea-field"
+          onClick={() => textareaFieldRef.current?.focus()}
+        >
+          Focus textarea
+        </button>
+      </div>
+
+      <div className="flex items-end gap-2">
+        <label htmlFor="ref-select">Fruit</label>
+        <Select
+          id="ref-select"
+          items={fruits}
+          value={selectValue}
+          onChange={setSelectValue}
+          placeholder="Select fruit"
+          data={{ test: 'ref-select' }}
+          ref={selectRef}
+        />
+        <button
+          type="button"
+          data-test="focus-select"
+          onClick={() => selectRef.current?.focus()}
+        >
+          Focus select
+        </button>
+      </div>
+
+      <div className="flex items-end gap-2">
+        <Combobox
+          items={frameworks}
+          value={comboboxValue}
+          onChange={setComboboxValue}
+          ariaLabel="Framework"
+          data={{ test: 'ref-combobox' }}
+          ref={comboboxRef}
+        />
+        <button
+          type="button"
+          data-test="focus-combobox"
+          onClick={() => comboboxRef.current?.focus()}
+        >
+          Focus combobox
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/design-system/src/Select.tsx
+++ b/packages/design-system/src/Select.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { Ref } from 'react'
 import { useEffect, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import Tooltip from './Tooltip' // New import for tooltips
@@ -41,6 +42,7 @@ interface SelectProps {
   contentPosition?: 'item-aligned' | 'popper'
   ariaRequired?: boolean
   ariaDescribedBy?: string
+  ref?: Ref<HTMLButtonElement>
 }
 
 export interface SelectItem {
@@ -112,6 +114,7 @@ const ItemContent = ({ item }: { item: SelectItem }) => (
  * @param contentPosition - The position of the content of the select component. Currently only 'item-aligned' and 'popper' are supported.
  * @param ariaRequired - Forwarded to the trigger as aria-required to expose the required state to assistive technology.
  * @param ariaDescribedBy - Forwarded to the trigger as aria-describedby to link an external description such as an error message.
+ * @param ref - A ref to the visible trigger button.
  * @return Select component
  */
 export function Select({
@@ -131,6 +134,7 @@ export function Select({
   contentPosition = 'item-aligned',
   ariaRequired,
   ariaDescribedBy,
+  ref,
 }: SelectWithItemsProps | SelectWithGroupsProps) {
   const [open, setOpen] = useState(false)
   const [shortLabel, setShortLabel] = useState<string | undefined>(undefined)
@@ -157,6 +161,7 @@ export function Select({
       >
         <SelectTrigger
           id={id}
+          ref={ref}
           aria-required={ariaRequired || undefined}
           aria-describedby={ariaDescribedBy}
           data-cy={data?.cy}

--- a/packages/design-system/src/forms/NumberField.tsx
+++ b/packages/design-system/src/forms/NumberField.tsx
@@ -42,6 +42,7 @@ export interface NumberFieldProps {
     test?: string
   }
   className?: NumberFieldClassName
+  ref?: React.Ref<HTMLInputElement>
   [key: string]: unknown
 }
 
@@ -69,6 +70,7 @@ export interface NumberFieldProps {
  * @param onBlur - The onBlur function of the input field.
  * @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy)
  * @param className - The optional className object allows you to override the default styling.
+ * @param ref - A ref to the underlying input element.
  */
 export function NumberField({
   id,
@@ -92,6 +94,7 @@ export function NumberField({
   onBlur,
   data,
   className,
+  ref,
   ...props
 }: NumberFieldProps): React.ReactElement {
   const { inputId, visibleError, errorId } = useFieldError({
@@ -198,6 +201,7 @@ export function NumberField({
           )}
           <Input
             id={inputId}
+            ref={ref}
             aria-required={required || undefined}
             aria-describedby={visibleError ? errorId : undefined}
             data-cy={data?.cy}

--- a/packages/design-system/src/forms/TextField.tsx
+++ b/packages/design-system/src/forms/TextField.tsx
@@ -42,6 +42,7 @@ interface TextFieldProps {
   onIconClick?: () => void
   onEnter?: (event: React.KeyboardEvent<HTMLInputElement>) => void
   onReset?: () => void
+  ref?: React.Ref<HTMLInputElement>
 }
 
 export interface TextFieldNameProps extends TextFieldProps {
@@ -85,6 +86,7 @@ export interface TextFieldOnChangeProps extends TextFieldProps {
  * @param onIconClick - The optional onIconClick function is called when the icon is clicked.
  * @param onEnter - The optional onEnter function is called when the user presses the Enter key in the input field.
  * @param onReset - The optional onReset function adds a cancellation icon to the text field (right side; replacing icons positioned there)
+ * @param ref - A ref to the underlying input element.
  * @returns Text field component with optional label, tooltip, error message and icon.
  */
 
@@ -111,6 +113,7 @@ export function TextField({
   onIconClick,
   onEnter,
   onReset,
+  ref,
   ...props
 }: TextFieldNameProps | TextFieldOnChangeProps) {
   const { inputId, visibleError, errorId } = useFieldError({
@@ -144,6 +147,7 @@ export function TextField({
             <Input
               {...field}
               id={inputId}
+              ref={ref}
               aria-required={required || undefined}
               aria-describedby={visibleError ? errorId : undefined}
               data-cy={data?.cy}
@@ -178,6 +182,7 @@ export function TextField({
           ) : (
             <Input
               id={inputId}
+              ref={ref}
               aria-required={required || undefined}
               aria-describedby={visibleError ? errorId : undefined}
               data-cy={data?.cy}

--- a/packages/design-system/src/forms/TextareaField.tsx
+++ b/packages/design-system/src/forms/TextareaField.tsx
@@ -34,6 +34,7 @@ interface TextareaFieldProps {
     error?: string
     tooltip?: string
   }
+  ref?: React.Ref<HTMLTextAreaElement>
 }
 
 export interface TextareaFieldNameProps extends TextareaFieldProps {
@@ -74,6 +75,7 @@ export interface TextareaFieldOnChangeProps extends TextareaFieldProps {
  * @param error - The error message that is shown below the field.
  * @param disabled - Indicate whether the field is disabled or not.
  * @param className - The optional className object allows you to override the default styling.
+ * @param ref - A ref to the underlying textarea element.
  * @returns Text field component with optional label, tooltip, error message and icon.
  */
 export function TextareaField({
@@ -96,6 +98,7 @@ export function TextareaField({
   error,
   disabled,
   className,
+  ref,
   ...props
 }: TextareaFieldNameProps | TextareaFieldOnChangeProps) {
   const { inputId, visibleError, errorId } = useFieldError({
@@ -129,6 +132,7 @@ export function TextareaField({
             <Textarea
               {...field}
               id={inputId}
+              ref={ref}
               aria-required={required || undefined}
               aria-describedby={visibleError ? errorId : undefined}
               data-cy={data?.cy}
@@ -150,6 +154,7 @@ export function TextareaField({
           ) : (
             <Textarea
               id={inputId}
+              ref={ref}
               aria-required={required || undefined}
               aria-describedby={visibleError ? errorId : undefined}
               data-cy={data?.cy}

--- a/packages/design-system/tests/contracts/direct-control-refs.spec.ts
+++ b/packages/design-system/tests/contracts/direct-control-refs.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test'
+
+import { gotoStory } from '../_support/ladle'
+
+const story = 'direct-control-refs--default'
+
+test.describe('direct-control ref contracts', () => {
+  test('focuses every public direct-control target', async ({ page }) => {
+    await gotoStory(page, story)
+
+    const cases = [
+      ['focus-button', 'ref-button'],
+      ['focus-text-field', 'ref-text-field'],
+      ['focus-number-field', 'ref-number-field'],
+      ['focus-textarea-field', 'ref-textarea-field'],
+      ['focus-select', 'ref-select'],
+      ['focus-combobox', 'ref-combobox'],
+    ] as const
+
+    for (const [action, target] of cases) {
+      await page.locator(`[data-test="${action}"]`).click()
+      await expect(page.locator(`[data-test="${target}"]`)).toBeFocused()
+    }
+  })
+
+  test('keeps Select trigger selection and focus return intact', async ({
+    page,
+  }) => {
+    await gotoStory(page, story)
+
+    const trigger = page.locator('[data-test="ref-select"]')
+    await page.locator('[data-test="focus-select"]').click()
+    await expect(trigger).toBeFocused()
+
+    await page.keyboard.press('Enter')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    await page.keyboard.press('ArrowDown')
+    await expect(
+      page.locator('[data-slot="select-item"][data-highlighted]')
+    ).toContainText('Banana')
+    await page.keyboard.press('Enter')
+    await expect(trigger).toContainText('Banana')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    await expect(trigger).toBeFocused()
+
+    await page.keyboard.press('Enter')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    await page.keyboard.press('Escape')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    await expect(trigger).toBeFocused()
+  })
+
+  test('keeps Combobox selection and focus return intact', async ({ page }) => {
+    await gotoStory(page, story)
+
+    const trigger = page.locator('[data-test="ref-combobox"]')
+    await page.locator('[data-test="focus-combobox"]').click()
+    await expect(trigger).toBeFocused()
+
+    await page.keyboard.press('Enter')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    const search = page.getByRole('combobox', { name: 'Search…' })
+    await expect(search).toBeFocused()
+    await page.keyboard.press('Enter')
+    await expect(trigger).toContainText('React')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    await expect(trigger).toBeFocused()
+
+    await page.keyboard.press('Enter')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    await page.keyboard.press('Escape')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    await expect(trigger).toBeFocused()
+  })
+})

--- a/packages/design-system/tests/contracts/direct-control-refs.types.ts
+++ b/packages/design-system/tests/contracts/direct-control-refs.types.ts
@@ -1,0 +1,115 @@
+import type {
+  ButtonProps,
+  ComboboxProps,
+  NumberFieldProps,
+  SelectWithItemsProps,
+  TextareaFieldOnChangeProps,
+  TextFieldOnChangeProps,
+} from '../../src'
+
+const buttonRef = (element: HTMLButtonElement | null) => {
+  void element
+}
+const inputRef = (element: HTMLInputElement | null) => {
+  void element
+}
+const textareaRef = (element: HTMLTextAreaElement | null) => {
+  void element
+}
+const wrongRef = (element: HTMLDivElement | null) => {
+  void element
+}
+const wrongObjectRef = { current: null as HTMLDivElement | null }
+
+function acceptsButtonProps(props: ButtonProps) {
+  return props
+}
+
+acceptsButtonProps({ ref: buttonRef })
+
+// @ts-expect-error A native button ref is not sound when Button renders an arbitrary child.
+acceptsButtonProps({ asChild: true, ref: buttonRef })
+
+// @ts-expect-error Button refs must target the native button element.
+acceptsButtonProps({ ref: wrongRef })
+
+function acceptsTextFieldProps(props: TextFieldOnChangeProps) {
+  return props
+}
+
+acceptsTextFieldProps({
+  value: '',
+  onChange: () => undefined,
+  ref: inputRef,
+})
+
+acceptsTextFieldProps({
+  value: '',
+  onChange: () => undefined,
+  // @ts-expect-error TextField refs must target the underlying input element.
+  ref: wrongObjectRef,
+})
+
+function acceptsNumberFieldProps(props: NumberFieldProps) {
+  return props
+}
+
+acceptsNumberFieldProps({ value: '', onChange: () => undefined, ref: inputRef })
+
+acceptsNumberFieldProps({
+  value: '',
+  onChange: () => undefined,
+  // @ts-expect-error NumberField refs must target the underlying input element.
+  ref: wrongObjectRef,
+})
+
+function acceptsTextareaFieldProps(props: TextareaFieldOnChangeProps) {
+  return props
+}
+
+acceptsTextareaFieldProps({
+  value: '',
+  onChange: () => undefined,
+  ref: textareaRef,
+})
+
+acceptsTextareaFieldProps({
+  value: '',
+  onChange: () => undefined,
+  // @ts-expect-error TextareaField refs must target the underlying textarea element.
+  ref: wrongRef,
+})
+
+function acceptsSelectProps(props: SelectWithItemsProps) {
+  return props
+}
+
+acceptsSelectProps({
+  items: [{ value: 'one', label: 'One' }],
+  onChange: () => undefined,
+  ref: buttonRef,
+})
+
+acceptsSelectProps({
+  items: [{ value: 'one', label: 'One' }],
+  onChange: () => undefined,
+  // @ts-expect-error Select refs must target the visible trigger button.
+  ref: wrongRef,
+})
+
+function acceptsComboboxProps(props: ComboboxProps) {
+  return props
+}
+
+acceptsComboboxProps({
+  items: [{ value: 'one', label: 'One' }],
+  onChange: () => undefined,
+  ref: buttonRef,
+})
+
+acceptsComboboxProps({
+  items: [{ value: 'one', label: 'One' }],
+  onChange: () => undefined,
+  // @ts-expect-error Combobox refs must target the visible trigger button.
+  ref: wrongRef,
+})

--- a/packages/design-system/tests/contracts/public-contracts.types.ts
+++ b/packages/design-system/tests/contracts/public-contracts.types.ts
@@ -17,12 +17,6 @@ acceptsButtonProps({
 // @ts-expect-error Arbitrary composite props are not part of the v5 contract.
 acceptsButtonProps({ unsupportedProp: true })
 
-const buttonRef = (element: HTMLButtonElement | null) => {
-  void element
-}
-// @ts-expect-error Ref support belongs to the A2 direct-control-ref layer.
-acceptsButtonProps({ ref: buttonRef })
-
 function acceptsNavigationProps(props: NavigationProps) {
   return props
 }

--- a/packages/design-system/tsconfig.types.json
+++ b/packages/design-system/tsconfig.types.json
@@ -5,5 +5,8 @@
     "noEmit": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.types.tsbuildinfo"
   },
-  "include": ["tests/contracts/public-contracts.types.ts"]
+  "include": [
+    "tests/contracts/public-contracts.types.ts",
+    "tests/contracts/direct-control-refs.types.ts"
+  ]
 }

--- a/project/2026-08-01-pr-187-v5-direct-control-refs-plan.md
+++ b/project/2026-08-01-pr-187-v5-direct-control-refs-plan.md
@@ -165,7 +165,11 @@ imperative focus.
   high-confidence exploitable vulnerabilities. Differential Opengrep found
   zero findings introduced by the stack; its one current finding is
   pre-existing in the `v5` baseline.
-- Next: publish Stack A as draft PRs targeting `v5` only. Keep `main` out of
+- 2026-08-02: Draft [PR #187](https://github.com/uzh-bf/design-system/pull/187)
+  was published as the dependent A2 layer on [PR #186](https://github.com/uzh-bf/design-system/pull/186).
+  Both PRs target the `v5` release line; the empty A3 placeholder remains
+  local and unsubmitted.
+- Next: await CI and reviewer feedback on the draft PRs. Keep `main` out of
   the stack and do not merge or queue any branch from this checkpoint.
 
 ## Commit boundaries

--- a/project/2026-08-01-pr-187-v5-direct-control-refs-plan.md
+++ b/project/2026-08-01-pr-187-v5-direct-control-refs-plan.md
@@ -70,8 +70,9 @@ imperative focus.
 - Layer: A2 of 3
 - Worktree: `trees/rs-v5-direct-control-refs`
 - Branch: `rs/v5-direct-control-refs`
+- PR: [#187](https://github.com/uzh-bf/design-system/pull/187)
 - Target/trunk: `v5` at `4aa021ac2b8fd43cad6076dcc30071feb87d97f6`
-- Parent: A1 `rs/v5-prop-contracts` at `a6610f822869eeca5759699641c68b6d8dc6e908`
+- Parent: A1 `rs/v5-prop-contracts` at `8ac3bfadcb44fa008e669ffc8ffdb268ce5f2b90`
 - Dependent: A3 `rs/v5-composite-refs`
 - Native stack: `trunk: v5`; all branches are local and unqueued. A2 and its
   dependent A3 currently point at this plan commit while A1 remains the parent.

--- a/project/2026-08-01-pr-187-v5-direct-control-refs-plan.md
+++ b/project/2026-08-01-pr-187-v5-direct-control-refs-plan.md
@@ -116,9 +116,9 @@ imperative focus.
 - Exact-range current-provider plan review before implementation.
 - Exact-range implementation review after the implementation commit.
 - Separate simplification pass after implementation review.
-- Final Stack A security and maintainability gates remain required before any
-  draft stack publication or ready-for-review decision; no publication is part
-  of this A2 slice.
+- Final Stack A security and maintainability gates were required before draft
+  publication and are recorded in Progress. PR #187 is now published as a
+  draft; no ready-for-review or merge action is included in this slice.
 
 ## Progress
 

--- a/project/2026-08-01-v5-direct-control-refs-plan.md
+++ b/project/2026-08-01-v5-direct-control-refs-plan.md
@@ -151,10 +151,10 @@ imperative focus.
   `e9cc32a` Modal correction against the rebuilt bundle and the targeted
   neutral/uzh checks (2/2); the complete rerun is recorded above as 770/770.
 - 2026-08-01: Native `gh stack rebase --no-trunk` completed after the final
-  A2 evidence checkpoint. A3 now bases on `7ce1706`, all local stack entries
-  report `needsRebase: false`, and `v5`/`origin/v5` remain at `4aa021a`. A
-  recovery snapshot for this transition is under
-  `refs/stack-backup/20260801-233612/`.
+  A2 evidence checkpoint. A3 now bases on the finalized A2 branch, all local
+  stack entries report `needsRebase: false`, and `v5`/`origin/v5` remain at
+  `4aa021a`. Recovery snapshots for the stack transitions remain under
+  `refs/stack-backup/`.
 - Next: keep Stack A security and maintainability gates before any draft
   publication or ready-for-review decision. No push, PR submission, queue,
   merge, or `main` target is authorized here.

--- a/project/2026-08-01-v5-direct-control-refs-plan.md
+++ b/project/2026-08-01-v5-direct-control-refs-plan.md
@@ -155,9 +155,17 @@ imperative focus.
   stack entries report `needsRebase: false`, and `v5`/`origin/v5` remain at
   `4aa021a`. Recovery snapshots for the stack transitions remain under
   `refs/stack-backup/`.
-- Next: keep Stack A security and maintainability gates before any draft
-  publication or ready-for-review decision. No push, PR submission, queue,
-  merge, or `main` target is authorized here.
+- 2026-08-02: Final Stack A thermo-nuclear maintainability review over
+  `4aa021a..65b2bc6` passed with no structural, abstraction, boundary,
+  duplication, spaghetti-growth, or file-size findings. The largest changed
+  file is `Navigation.tsx` at 531 lines; fresh TypeScript and changed-file
+  ESLint checks also passed.
+- 2026-08-02: Bounded security review over `4aa021a..65b2bc6` found no
+  high-confidence exploitable vulnerabilities. Differential Opengrep found
+  zero findings introduced by the stack; its one current finding is
+  pre-existing in the `v5` baseline.
+- Next: publish Stack A as draft PRs targeting `v5` only. Keep `main` out of
+  the stack and do not merge or queue any branch from this checkpoint.
 
 ## Commit boundaries
 

--- a/project/2026-08-01-v5-direct-control-refs-plan.md
+++ b/project/2026-08-01-v5-direct-control-refs-plan.md
@@ -134,17 +134,20 @@ imperative focus.
   and public-contract type checks, changed-file ESLint, Prettier, package
   `tsc -b`, Vite build, font/licence extraction, and Ladle production build.
 - 2026-08-01: Focused direct-control Playwright proof passed 3/3 tests. The
-  full `tests/a11y` suite completed 768/770; both direct-control story entries
-  passed and the canary passed. The only failures were the two pre-existing
-  `modal--trigger` color-contrast findings (neutral and uzh), already outside
-  this slice's changed surface.
+  first full `tests/a11y` run completed 768/770 and exposed the two
+  `modal--trigger` color-contrast findings (neutral and uzh). Exact-range
+  implementation review confirmed that the inherited A1 story change was in
+  this reviewed stack, so it was corrected in `e9cc32a` by using the public
+  `Button` contract while retaining the story's style mapping. The targeted
+  Modal a11y proof and the rerun of the complete suite then passed 770/770,
+  including both direct-control story entries and the canary.
 - 2026-08-01: Simplification review found one documentation follow-up: the
   `ButtonProps` interface-to-union change can affect consumer wrappers that use
   `interface ... extends ButtonProps`; the migration note now shows the
   intersection form. An ADR was suggested as a future governance improvement,
   but is not required to complete this approved A2 slice.
-- Next: complete the exact-range implementation review, record any verified
-  follow-up, and rebase the local A3 dependent onto the finalized A2 head.
+- Next: record the final exact-range review outcome and rebase the local A3
+  dependent onto the finalized A2 head.
   Stack A security/maintainability gates remain required before any draft
   publication or ready-for-review decision. No push, PR submission, queue,
   merge, or `main` target is authorized here.
@@ -154,7 +157,10 @@ imperative focus.
 - `docs(project): add v5 direct-control refs plan` — this plan only.
 - `feat(refs): expose v5 direct-control refs` — A2 implementation, durable
   type proof, focused story/test, and migration note after verification.
-- Follow-up commits must remain narrowly scoped to verified review findings.
+- `fix(stories): preserve modal trigger contrast` — verified implementation-
+  review follow-up for the inherited Modal trigger story.
+- Follow-up documentation commits must remain narrowly scoped to verified
+  review findings and verification evidence.
 
 ## Out of scope / follow-ups
 

--- a/project/2026-08-01-v5-direct-control-refs-plan.md
+++ b/project/2026-08-01-v5-direct-control-refs-plan.md
@@ -1,0 +1,137 @@
+# Plan — v5 direct-control refs (Stack A2)
+
+## Problem
+
+A1 deliberately rejects `ref` on the strict public contracts while the
+underlying React 19 primitives already have concrete ref targets. Consumers
+cannot currently focus the public `Button`, single-input fields, or
+`Select`/`Combobox` triggers through the component boundary. The public API
+needs one React 19 ref-as-prop convention before v5 consumers start relying on
+imperative focus.
+
+## Evidence
+
+- `packages/design-system/src/Button.tsx` composes the shadcn button with
+  `ComponentPropsWithoutRef`; it renders the interactive button but exposes no
+  public `ref` prop.
+- `packages/design-system/src/forms/TextField.tsx`, `NumberField.tsx`, and
+  `TextareaField.tsx` each render one underlying input or textarea while their
+  public props do not name a concrete ref target.
+- `packages/design-system/src/Select.tsx` renders a decorative wrapper around
+  a `SelectTrigger` button; a ref must land on that trigger, not the wrapper or
+  the Radix root.
+- `packages/design-system/src/Combobox.tsx` renders a disclosure button through
+  `PopoverTrigger`; a ref must land on the visible trigger, not the popover or
+  command input.
+- The repository uses React `^19.1.0`, and the approved roadmap requires the
+  normal React 19 ref-as-prop contract rather than a second `forwardedRef` API.
+
+## Decision
+
+- Add an explicit, concrete `ref` prop to each in-scope public contract:
+  `HTMLButtonElement` for `Button` and `Select`/`Combobox` triggers,
+  `HTMLInputElement` for `TextField` and `NumberField`, and
+  `HTMLTextAreaElement` for `TextareaField`.
+- Pass the ref through the existing primitive boundary without introducing a
+  wrapper or changing event, keyboard, accessibility, theme, or loading
+  behavior. The default `Button` native-button path is the A2 target; alternate
+  `asChild` element contracts remain a follow-up if their target cannot be
+  typed without weakening the concrete ref guarantee.
+- Keep `Select` and `Combobox` refs on their visible interactive triggers. Do
+  not expose refs to decorative wrappers, portals, command search inputs, or
+  internal Radix roots.
+- Keep the A2 surface limited to direct controls and single-input field
+  wrappers. Deprecated `Formik*` wrappers, OTP/date/color-picker composites,
+  passive layout components, and `Table.forwardedRef` remain outside A2; A3
+  owns composite ref inventory and the Table migration.
+- Do not add a compatibility alias named `forwardedRef`; the v5 breaking-change
+  policy permits the normal `ref` contract.
+
+## Risk
+
+- A ref can compile while landing on a wrapper or a non-interactive descendant;
+  runtime focus assertions must prove the actual active element for every target
+  class.
+- `Button` supports `asChild`; claiming an `HTMLButtonElement` ref for an
+  arbitrary child would be unsound. Keep the A2 type/runtime proof on the
+  native-button path and record any child-target need as a follow-up.
+- `Select` and `Combobox` have controlled state and portals. Ref wiring must not
+  change open/close behavior, keyboard navigation, accessible names, or the
+  selected value.
+- Existing field variants have Formik and controlled branches. Both branches
+  must forward the same concrete ref target without changing validation or
+  event ordering.
+
+## Approved stack context
+
+- Stack: A — public component contracts
+- Layer: A2 of 3
+- Worktree: `trees/rs-v5-direct-control-refs`
+- Branch: `rs/v5-direct-control-refs`
+- Target/trunk: `v5` at `4aa021ac2b8fd43cad6076dcc30071feb87d97f6`
+- Parent: A1 `rs/v5-prop-contracts` at `a6610f822869eeca5759699641c68b6d8dc6e908`
+- Dependent: A3 `rs/v5-composite-refs`
+- Native stack: `trunk: v5`; all branches are local, unqueued, and currently
+  aligned at the A1 parent. Never target or merge this stack into `main`.
+
+## Do
+
+1. Add the explicit ref props and thread them to the concrete DOM targets in
+   Button, TextField, NumberField, TextareaField, Select, and Combobox.
+2. Add durable no-emit type cases covering valid target refs and negative
+   wrong-target refs for every in-scope class. Keep the fixture in the package's
+   normal `check` gate.
+3. Add one focused Ladle contract story and Playwright proof. Each story control
+   must expose a deterministic action that focuses its ref target; each test
+   must assert `document.activeElement` is the visible interactive element.
+4. Update the migration guide with the concrete ref target map and the rule
+   that A2 uses `ref`, not `forwardedRef`. Do not document deferred composite
+   or Table migration as completed.
+
+## Check
+
+- Direct package type check plus the durable ref fixture through the existing
+  `check` script.
+- Direct ESLint on every changed TypeScript file with
+  `--report-unused-disable-directives --max-warnings 0`.
+- Prettier on changed code, fixture, story, docs, and plan files; preserve the
+  known pre-existing formatter drift in legacy MDX stories.
+- Mandatory package `tsc`/Vite/font-copy build and Ladle production build.
+- Focused Playwright proof for Button, TextField, NumberField, TextareaField,
+  Select, and Combobox ref-driven focus.
+- Existing stories and focused a11y behavior remain green; no visual output or
+  non-ref interaction behavior intentionally changes.
+
+## Review routing
+
+- Exact-range current-provider plan review before implementation.
+- Exact-range implementation review after the implementation commit.
+- Separate simplification pass after implementation review.
+- Final Stack A security and maintainability gates remain required before any
+  draft stack publication or ready-for-review decision; no publication is part
+  of this A2 slice.
+
+## Progress
+
+- 2026-08-01: A1 Gate 2 was approved. The native no-trunk rebase completed with
+  `v5` untouched; recovery refs are recorded under
+  `refs/stack-backup/20260801-220941/`.
+- Next: commit this plan, obtain exact-range plan review, then implement only
+  the six direct-control classes above. No push, PR submission, queue, merge,
+  or `main` target is authorized here.
+
+## Commit boundaries
+
+- `docs(project): add v5 direct-control refs plan` — this plan only.
+- `feat(refs): expose v5 direct-control refs` — A2 implementation, durable
+  type proof, focused story/test, and migration note after verification.
+- Follow-up commits must remain narrowly scoped to verified review findings.
+
+## Out of scope / follow-ups
+
+- A3 composite refs, including deprecated Formik wrappers where they require a
+  separate migration decision, OTP/date/color-picker composites, and Table's
+  `forwardedRef` removal.
+- Stack B selector normalization, Stack C bundle boundaries, Stack D VRT, and
+  D8 theme override/migration work.
+- Repairing the pnpm registry-signature/toolchain issue.

--- a/project/2026-08-01-v5-direct-control-refs-plan.md
+++ b/project/2026-08-01-v5-direct-control-refs-plan.md
@@ -146,9 +146,16 @@ imperative focus.
   `interface ... extends ButtonProps`; the migration note now shows the
   intersection form. An ADR was suggested as a future governance improvement,
   but is not required to complete this approved A2 slice.
-- Next: record the final exact-range review outcome and rebase the local A3
-  dependent onto the finalized A2 head.
-  Stack A security/maintainability gates remain required before any draft
+- 2026-08-01: Final exact-range implementation review over
+  `4aa021a..7ce1706` passed with no findings. It independently verified the
+  `e9cc32a` Modal correction against the rebuilt bundle and the targeted
+  neutral/uzh checks (2/2); the complete rerun is recorded above as 770/770.
+- 2026-08-01: Native `gh stack rebase --no-trunk` completed after the final
+  A2 evidence checkpoint. A3 now bases on `7ce1706`, all local stack entries
+  report `needsRebase: false`, and `v5`/`origin/v5` remain at `4aa021a`. A
+  recovery snapshot for this transition is under
+  `refs/stack-backup/20260801-233612/`.
+- Next: keep Stack A security and maintainability gates before any draft
   publication or ready-for-review decision. No push, PR submission, queue,
   merge, or `main` target is authorized here.
 

--- a/project/2026-08-01-v5-direct-control-refs-plan.md
+++ b/project/2026-08-01-v5-direct-control-refs-plan.md
@@ -34,9 +34,10 @@ imperative focus.
   `HTMLTextAreaElement` for `TextareaField`.
 - Pass the ref through the existing primitive boundary without introducing a
   wrapper or changing event, keyboard, accessibility, theme, or loading
-  behavior. The default `Button` native-button path is the A2 target; alternate
-  `asChild` element contracts remain a follow-up if their target cannot be
-  typed without weakening the concrete ref guarantee.
+  behavior. Model `Button` as a discriminated contract: the native-button path
+  (`asChild` omitted or `false`) accepts `React.Ref<HTMLButtonElement>`, while
+  `asChild: true` rejects `ref` until a sound polymorphic child-target contract
+  is designed. Do not claim an `HTMLButtonElement` ref for an arbitrary child.
 - Keep `Select` and `Combobox` refs on their visible interactive triggers. Do
   not expose refs to decorative wrappers, portals, command search inputs, or
   internal Radix roots.
@@ -54,7 +55,8 @@ imperative focus.
   class.
 - `Button` supports `asChild`; claiming an `HTMLButtonElement` ref for an
   arbitrary child would be unsound. Keep the A2 type/runtime proof on the
-  native-button path and record any child-target need as a follow-up.
+  native-button path, reject `asChild` plus `ref` in the type fixture, and record
+  any child-target need as a follow-up.
 - `Select` and `Combobox` have controlled state and portals. Ref wiring must not
   change open/close behavior, keyboard navigation, accessible names, or the
   selected value.
@@ -71,19 +73,23 @@ imperative focus.
 - Target/trunk: `v5` at `4aa021ac2b8fd43cad6076dcc30071feb87d97f6`
 - Parent: A1 `rs/v5-prop-contracts` at `a6610f822869eeca5759699641c68b6d8dc6e908`
 - Dependent: A3 `rs/v5-composite-refs`
-- Native stack: `trunk: v5`; all branches are local, unqueued, and currently
-  aligned at the A1 parent. Never target or merge this stack into `main`.
+- Native stack: `trunk: v5`; all branches are local and unqueued. A2 and its
+  dependent A3 currently point at this plan commit while A1 remains the parent.
+  Never target or merge this stack into `main`.
 
 ## Do
 
 1. Add the explicit ref props and thread them to the concrete DOM targets in
    Button, TextField, NumberField, TextareaField, Select, and Combobox.
 2. Add durable no-emit type cases covering valid target refs and negative
-   wrong-target refs for every in-scope class. Keep the fixture in the package's
+   wrong-target refs for every in-scope class, including the invalid
+   `Button asChild` plus `ref` combination. Keep the fixture in the package's
    normal `check` gate.
 3. Add one focused Ladle contract story and Playwright proof. Each story control
    must expose a deterministic action that focuses its ref target; each test
-   must assert `document.activeElement` is the visible interactive element.
+   must assert `document.activeElement` is the visible interactive element. For
+   Select and Combobox, activate the focused trigger and exercise the existing
+   open, keyboard-select, close, and focus-return path as well as the ref check.
 4. Update the migration guide with the concrete ref target map and the rule
    that A2 uses `ref`, not `forwardedRef`. Do not document deferred composite
    or Table migration as completed.
@@ -98,9 +104,11 @@ imperative focus.
   known pre-existing formatter drift in legacy MDX stories.
 - Mandatory package `tsc`/Vite/font-copy build and Ladle production build.
 - Focused Playwright proof for Button, TextField, NumberField, TextareaField,
-  Select, and Combobox ref-driven focus.
-- Existing stories and focused a11y behavior remain green; no visual output or
-  non-ref interaction behavior intentionally changes.
+  Select, and Combobox ref-driven focus plus the Select/Combobox interaction
+  contract described above.
+- Full repository `tests/a11y` Playwright suite, run separately from the
+  focused ref proof, must remain green. Existing stories and non-ref
+  interaction behavior remain green; no visual output is intentionally changed.
 
 ## Review routing
 
@@ -116,9 +124,12 @@ imperative focus.
 - 2026-08-01: A1 Gate 2 was approved. The native no-trunk rebase completed with
   `v5` untouched; recovery refs are recorded under
   `refs/stack-backup/20260801-220941/`.
-- Next: commit this plan, obtain exact-range plan review, then implement only
-  the six direct-control classes above. No push, PR submission, queue, merge,
-  or `main` target is authorized here.
+- 2026-08-01: Exact-range plan review of `8821341` required the sound
+  `Button asChild`/`ref` discriminator, the full `tests/a11y` gate, and
+  Select/Combobox open-select-close assertions; those requirements are recorded
+  above before implementation.
+- Next: implement only the six direct-control classes above. No push, PR
+  submission, queue, merge, or `main` target is authorized here.
 
 ## Commit boundaries
 

--- a/project/2026-08-01-v5-direct-control-refs-plan.md
+++ b/project/2026-08-01-v5-direct-control-refs-plan.md
@@ -128,8 +128,26 @@ imperative focus.
   `Button asChild`/`ref` discriminator, the full `tests/a11y` gate, and
   Select/Combobox open-select-close assertions; those requirements are recorded
   above before implementation.
-- Next: implement only the six direct-control classes above. No push, PR
-  submission, queue, merge, or `main` target is authorized here.
+- 2026-08-01: A2 implementation committed as `f1d117b` after the six direct-
+  control contracts, durable no-emit fixture, consumer story, interaction proof,
+  and migration guidance were verified. Static gates passed: package source
+  and public-contract type checks, changed-file ESLint, Prettier, package
+  `tsc -b`, Vite build, font/licence extraction, and Ladle production build.
+- 2026-08-01: Focused direct-control Playwright proof passed 3/3 tests. The
+  full `tests/a11y` suite completed 768/770; both direct-control story entries
+  passed and the canary passed. The only failures were the two pre-existing
+  `modal--trigger` color-contrast findings (neutral and uzh), already outside
+  this slice's changed surface.
+- 2026-08-01: Simplification review found one documentation follow-up: the
+  `ButtonProps` interface-to-union change can affect consumer wrappers that use
+  `interface ... extends ButtonProps`; the migration note now shows the
+  intersection form. An ADR was suggested as a future governance improvement,
+  but is not required to complete this approved A2 slice.
+- Next: complete the exact-range implementation review, record any verified
+  follow-up, and rebase the local A3 dependent onto the finalized A2 head.
+  Stack A security/maintainability gates remain required before any draft
+  publication or ready-for-review decision. No push, PR submission, queue,
+  merge, or `main` target is authorized here.
 
 ## Commit boundaries
 


### PR DESCRIPTION
## What This Adds

## Landing status

Merged into `v5` as squash commit
`b7d72b5f309594ebfb02261c1fb35e85345a88bd` on 2026-08-02. `main` was not
targeted.

This is the second Stack A layer for v5 public component contracts. It exposes
React 19 direct-control refs for the controls whose DOM targets are stable:

- `Button` accepts an `HTMLButtonElement` ref on its native path. The
  `asChild: true` path rejects `ref` until a sound polymorphic child contract
  exists.
- `TextField` and `NumberField` forward `HTMLInputElement` refs.
- `TextareaField` forwards an `HTMLTextAreaElement` ref.
- `Select` and `Combobox` forward refs to their visible trigger buttons.
- Durable type fixtures, a consumer-facing Ladle story, focused interaction
  tests, and migration guidance cover the public contract.

This PR depends on [PR #186](https://github.com/uzh-bf/design-system/pull/186)
and targets `v5`, never `main`.

## How It Works

The components use the normal React 19 `ref` prop. Each ref is passed directly
to the existing interactive primitive, without a wrapper or `forwardedRef`
alias. The Select and Combobox proof covers focus, open, keyboard selection,
close, and focus return. The Modal story contrast correction is included as a
verified review follow-up from the same stack.

## Important Details

- `ButtonProps` is a discriminated union so a native button ref cannot be
  claimed for an arbitrary `asChild` element.
- The migration note shows how wrapper props should intersect `ButtonProps`
  instead of extending the union with an interface.
- Composite refs, deprecated Formik wrappers, OTP/date/color-picker controls,
  and the Table `forwardedRef` migration remain A3 follow-ups.

## Branch Coverage

- Base: `v5` at `66a3f64964937910d1c026a0b82185116245fa29`
- Head: `da408daa0293131def0df58f12d706f089228152`
- Reviewed: 12 commits; 610 additions and 21 deletions across 13 files.
- Covered: the A2 plan, six direct-control implementations, type fixtures,
  story and interaction proof, migration guidance, Modal review fix, and final
  gate records.
- Plan: `project/2026-08-01-pr-187-v5-direct-control-refs-plan.md`

## Review Focus

- Check the concrete ref target for each component rather than accepting a ref
  that lands on a wrapper or portal.
- Review the `Button` native versus `asChild` type boundary.
- Review Select and Combobox keyboard and focus-return behavior.
- Keep this PR dependent on PR #186 and leave A3 composite work out of scope.

## Verification

Current head:

- Direct source and public-contract TypeScript checks -> pass.
- Changed-file ESLint with unused-disable reporting and zero warnings -> pass.
- Package `tsc -b`, Vite build, font/licence extraction, and Ladle production
  build -> pass.
- Focused direct-control Playwright proof -> 3/3 pass.
- Targeted Modal a11y proof in neutral and uzh themes -> 2/2 pass.
- Full `tests/a11y` suite -> 770/770 pass, including the direct-control story,
  Modal trigger, and harness canary.

Earlier branch verification:

- The final thermo-nuclear and bounded security reviews passed on the exact
  Stack A range. Subsequent commits only renamed or updated the two plan files;
  the package tree stayed unchanged.

Failed/Warning:

- The repository pnpm wrapper still stops at the pinned registry-signature
  check. Direct installed binaries were used for local verification; no
  override or dependency mutation was introduced.
- Known legacy MDX formatting drift remains outside the implementation change.

CI status after publication:

- Formatting, Types, Lint, build, Build and Publish, all four A11y shards,
  Greptile, and Vercel passed.
- Test passed all 456 smoke stories, including `public-contracts--readme` and
  `direct-control-refs--readme`.
- `deploy` remains skipped by design.

## Visual Evidence

No screenshot artifact is included because A2 changes ref wiring and contract
proof rather than component visuals. The deployed [Vercel Ladle preview](https://vercel.com/roland-schlflis-projects/design-system-ladle/DTE8pX2bG3oNqE1vUqmaDuQ2NfDs)
and the focused plus full a11y browser checks cover the changed stories.

## Security / Privacy

- Final thermo-nuclear maintainability review found no structural,
  abstraction, boundary, duplication, spaghetti-growth, or file-size blocker.
- Bounded security review found no high-confidence exploitable vulnerabilities.
- Differential Opengrep found zero findings introduced by the stack; its one
  current finding is pre-existing in the `v5` baseline.
- No secrets, private payloads, or personal data are included.

## Blocking Before Merge

- [x] GitHub CI, reviewer approval, and asynchronous stacked merge completed for [PR #187](https://github.com/uzh-bf/design-system/pull/187).

## Follow-Up After Merge

- The approved A2 direct-control ref layer is now part of `v5`.
- A3 owns composite refs, deprecated Formik wrappers, and Table migration.
- Keep the pnpm signature issue as a separate tooling follow-up.
