### PR TITLE
feat(refs): complete v5 composite ref contracts

### DIFF
--- a/packages/design-system/MIGRATION.md
+++ b/packages/design-system/MIGRATION.md
@@ -257,6 +257,9 @@ stable interactive target:
 | `DateRangePicker`      | `HTMLButtonElement` (the calendar trigger)         |
 | `DateTimePicker`       | `HTMLButtonElement` (the calendar trigger)         |
 
+`Slider` also accepts an optional `ariaLabel` for naming its focusable thumb
+when the surrounding UI does not provide an accessible label.
+
 `Table` exposes an imperative handle instead of a DOM node:
 
 ```tsx

--- a/packages/design-system/MIGRATION.md
+++ b/packages/design-system/MIGRATION.md
@@ -237,6 +237,47 @@ v5 also marks the package `"sideEffects": ["*.css"]` so consuming bundlers can
 tree-shake unused components while preserving the required stylesheet import — no
 action needed.
 
+### Composite refs and Table
+
+Applicable v5 composites now use React 19's normal `ref` prop for their one
+stable interactive target:
+
+| Component              | Ref target                                         |
+| ---------------------- | -------------------------------------------------- |
+| `Checkbox`             | `HTMLButtonElement` (Radix checkbox root)          |
+| `Switch`               | `HTMLButtonElement` (Radix switch root)            |
+| `Slider`               | `HTMLSpanElement` (the focusable thumb)            |
+| `Collapsible`          | `HTMLButtonElement` (the trigger)                  |
+| `Dropdown`             | `HTMLButtonElement` (the menu trigger)             |
+| `MultiSelect`          | `HTMLButtonElement` (the visible popover trigger)  |
+| `SelectField`          | `HTMLButtonElement` (the delegated Select trigger) |
+| `AlphaNumericPinField` | `HTMLInputElement` (the underlying OTP input)      |
+| `ColorPicker`          | `HTMLButtonElement` (the palette trigger)          |
+| `DatePicker`           | `HTMLButtonElement` (the calendar trigger)         |
+| `DateRangePicker`      | `HTMLButtonElement` (the calendar trigger)         |
+| `DateTimePicker`       | `HTMLButtonElement` (the calendar trigger)         |
+
+`Table` exposes an imperative handle instead of a DOM node:
+
+```tsx
+interface TableRef {
+  reset(): void
+}
+
+const tableRef = useRef<TableRef>(null)
+<Table ref={tableRef} ... />
+tableRef.current?.reset()
+```
+
+The former `forwardedRef` prop is removed; replace it with `ref` as shown above.
+The removed alias is not accepted as a compatibility prop. `TableRef` is
+exported from the package root and is the only supported Table ref target.
+
+`DateTimePickerRef` remains an exported type alias for `HTMLButtonElement` so
+type-only imports remain useful, but the old pseudo-handle's Date-valued
+`.value` property is gone. Read the selected date from the controlled `value`
+prop and `onChange` callback instead.
+
 ## Peer dependencies
 
 v5 no longer bundles its runtime libraries — every one is declared as a **peer

--- a/packages/design-system/src/Checkbox.tsx
+++ b/packages/design-system/src/Checkbox.tsx
@@ -97,7 +97,7 @@ export function Checkbox({
         defaultChecked
         checked={checked || partial}
         className={twMerge(
-          'border-input ring-offset-background focus-visible:ring-ring data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground disabled:bg-muted disabled:border-border focus-visible:outline-hidden peer shrink-0 cursor-pointer rounded-[4px] border-[1.5px] focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed',
+          'border-input ring-offset-background focus-visible:ring-ring data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground disabled:bg-muted disabled:border-border peer shrink-0 cursor-pointer rounded-[4px] border-[1.5px] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed',
           (checked || partial) && 'border-primary',
           disabled && 'cursor-not-allowed',
           checkboxSize[size],

--- a/packages/design-system/src/Checkbox.tsx
+++ b/packages/design-system/src/Checkbox.tsx
@@ -9,6 +9,7 @@ import { twMerge } from 'tailwind-merge'
 
 export interface CheckboxProps {
   id?: string
+  ref?: React.Ref<HTMLButtonElement>
   data?: {
     cy?: string
     test?: string
@@ -49,6 +50,7 @@ export interface CheckboxProps {
  */
 export function Checkbox({
   id,
+  ref,
   data,
   children,
   checked,
@@ -87,6 +89,7 @@ export function Checkbox({
     <div className="flex flex-row items-center gap-2">
       <RadixCheckbox.Root
         id={inputId}
+        ref={ref}
         aria-labelledby={label ? labelId : undefined}
         aria-label={!label ? ariaLabel : undefined}
         data-cy={data?.cy}
@@ -94,7 +97,7 @@ export function Checkbox({
         defaultChecked
         checked={checked || partial}
         className={twMerge(
-          'peer border-input ring-offset-background focus-visible:ring-ring data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground disabled:bg-muted disabled:border-border shrink-0 cursor-pointer rounded-[4px] border-[1.5px] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed',
+          'border-input ring-offset-background focus-visible:ring-ring data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground disabled:bg-muted disabled:border-border focus-visible:outline-hidden peer shrink-0 cursor-pointer rounded-[4px] border-[1.5px] focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed',
           (checked || partial) && 'border-primary',
           disabled && 'cursor-not-allowed',
           checkboxSize[size],

--- a/packages/design-system/src/Collapsible.tsx
+++ b/packages/design-system/src/Collapsible.tsx
@@ -9,6 +9,7 @@ import Button from './Button'
 
 export interface CollapsibleProps {
   id?: string
+  ref?: React.Ref<HTMLButtonElement>
   data?: {
     cy?: string
     test?: string
@@ -58,6 +59,7 @@ export interface CollapsibleProps {
  */
 export function Collapsible({
   id,
+  ref,
   data,
   open,
   onChange,
@@ -75,7 +77,7 @@ export function Collapsible({
     <RadixCollapsible.Root open={open} onOpenChange={onChange}>
       <div
         className={twMerge(
-          'border-border w-full rounded-md border-2 border-solid p-2 pb-0!',
+          'border-border pb-0! w-full rounded-md border-2 border-solid p-2',
           className?.root
         )}
       >
@@ -110,6 +112,7 @@ export function Collapsible({
             )}
           </div>
           <RadixCollapsible.Trigger
+            ref={ref}
             className={twMerge(
               'col-span-1 flex w-full cursor-pointer flex-col justify-end text-center disabled:cursor-not-allowed',
               className?.trigger

--- a/packages/design-system/src/Collapsible.tsx
+++ b/packages/design-system/src/Collapsible.tsx
@@ -77,7 +77,7 @@ export function Collapsible({
     <RadixCollapsible.Root open={open} onOpenChange={onChange}>
       <div
         className={twMerge(
-          'border-border pb-0! w-full rounded-md border-2 border-solid p-2',
+          'border-border w-full rounded-md border-2 border-solid p-2 pb-0!',
           className?.root
         )}
       >

--- a/packages/design-system/src/ColorPicker.tsx
+++ b/packages/design-system/src/ColorPicker.tsx
@@ -196,7 +196,7 @@ export function ColorPicker({
               side={side}
               align={align}
               className={twMerge(
-                'w-92 flex h-40 flex-row rounded-md p-1 shadow-md',
+                'flex h-40 w-92 flex-row rounded-md p-1 shadow-md',
                 className?.popover
               )}
             >
@@ -229,7 +229,7 @@ export function ColorPicker({
                     forId={inputId}
                     className={{
                       root: twMerge(
-                        'my-auto -mb-0.5 min-w-max text-base font-bold leading-6 text-gray-600',
+                        'my-auto -mb-0.5 min-w-max text-base leading-6 font-bold text-gray-600',
                         className?.inputLabel
                       ),
                       tooltip: twMerge(

--- a/packages/design-system/src/ColorPicker.tsx
+++ b/packages/design-system/src/ColorPicker.tsx
@@ -28,6 +28,7 @@ export interface ColorPickerClassName {
 }
 
 export interface ColorPickerProps {
+  ref?: React.Ref<HTMLButtonElement>
   color: string
   label?: string
   labelType?: 'small' | 'large'
@@ -95,6 +96,7 @@ const POPOVER_PLACEMENT = {
  * @returns A ColorPicker component that allows users to select a color and submit it.
  */
 export function ColorPicker({
+  ref,
   color,
   label,
   labelType = 'small',
@@ -168,6 +170,7 @@ export function ColorPicker({
           >
             <PopoverTrigger asChild>
               <Button
+                ref={ref}
                 aria-label={triggerAriaLabel}
                 aria-describedby={visibleError ? errorId : undefined}
                 disabled={disabled}
@@ -193,7 +196,7 @@ export function ColorPicker({
               side={side}
               align={align}
               className={twMerge(
-                'flex h-40 w-92 flex-row rounded-md p-1 shadow-md',
+                'w-92 flex h-40 flex-row rounded-md p-1 shadow-md',
                 className?.popover
               )}
             >
@@ -226,7 +229,7 @@ export function ColorPicker({
                     forId={inputId}
                     className={{
                       root: twMerge(
-                        'my-auto -mb-0.5 min-w-max text-base leading-6 font-bold text-gray-600',
+                        'my-auto -mb-0.5 min-w-max text-base font-bold leading-6 text-gray-600',
                         className?.inputLabel
                       ),
                       tooltip: twMerge(

--- a/packages/design-system/src/CompositeRefs.stories.mdx
+++ b/packages/design-system/src/CompositeRefs.stories.mdx
@@ -1,0 +1,273 @@
+import { useRef, useState } from 'react'
+import Checkbox from './Checkbox'
+import Collapsible from './Collapsible'
+import ColorPicker from './ColorPicker'
+import DatePicker from './DatePicker'
+import DateRangePicker from './DateRangePicker'
+import { DateTimePicker } from './DatetimePicker'
+import Dropdown from './Dropdown'
+import MultiSelect from './MultiSelect'
+import Slider from './Slider'
+import Switch from './Switch'
+import SelectField from './forms/SelectField'
+import AlphaNumericPinField from './forms/AlphaNumericPinField'
+
+{/* START README */}
+<div className="prose prose-sm max-w-none">
+This story is a consumer-facing contract harness for the v5 composite refs.
+Each action focuses the public ref target, including the visible trigger for
+stateful composites and the underlying input or slider thumb where applicable.
+</div>
+{/* END README */}
+
+export const Default = () => {
+  const checkboxRef = useRef(null)
+  const switchRef = useRef(null)
+  const sliderRef = useRef(null)
+  const collapsibleRef = useRef(null)
+  const dropdownRef = useRef(null)
+  const multiSelectRef = useRef(null)
+  const selectFieldRef = useRef(null)
+  const pinRef = useRef(null)
+  const colorPickerRef = useRef(null)
+  const datePickerRef = useRef(null)
+  const dateRangePickerRef = useRef(null)
+  const dateTimePickerRef = useRef(null)
+
+  const [checked, setChecked] = useState(false)
+  const [switchChecked, setSwitchChecked] = useState(false)
+  const [sliderValue, setSliderValue] = useState(5)
+  const [collapsibleOpen, setCollapsibleOpen] = useState(false)
+  const [multiValue, setMultiValue] = useState([])
+  const [selectValue, setSelectValue] = useState('')
+  const [pinValue, setPinValue] = useState('')
+  const [color, setColor] = useState('#262FAD')
+  const [date, setDate] = useState(undefined)
+  const [range, setRange] = useState(undefined)
+  const [dateTime, setDateTime] = useState(undefined)
+
+  return (
+    <div className="flex max-w-3xl flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Checkbox
+          ref={checkboxRef}
+          checked={checked}
+          onCheck={() => setChecked((value) => !value)}
+          label="Checkbox"
+          data={{ test: 'ref-checkbox' }}
+        />
+        <button
+          type="button"
+          data-test="focus-checkbox"
+          onClick={() => checkboxRef.current?.focus()}
+        >
+          Focus checkbox
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Switch
+          ref={switchRef}
+          checked={switchChecked}
+          onCheckedChange={setSwitchChecked}
+          label="Switch"
+          data={{ test: 'ref-switch' }}
+        />
+        <button
+          type="button"
+          data-test="focus-switch"
+          onClick={() => switchRef.current?.focus()}
+        >
+          Focus switch
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Slider
+          ref={sliderRef}
+          min={0}
+          max={10}
+          step={1}
+          value={sliderValue}
+          handleChange={setSliderValue}
+          labels={{ min: '0', mid: '5', max: '10' }}
+          dataThumb={{ test: 'ref-slider' }}
+        />
+        <button
+          type="button"
+          data-test="focus-slider"
+          onClick={() => sliderRef.current?.focus()}
+        >
+          Focus slider
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Collapsible
+          ref={collapsibleRef}
+          open={collapsibleOpen}
+          onChange={() => setCollapsibleOpen((value) => !value)}
+          staticContent="Static content"
+          customTrigger="Toggle"
+          data={{ test: 'ref-collapsible' }}
+        >
+          Collapsible content
+        </Collapsible>
+        <button
+          type="button"
+          data-test="focus-collapsible"
+          onClick={() => collapsibleRef.current?.focus()}
+        >
+          Focus collapsible
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Dropdown
+          ref={dropdownRef}
+          trigger="Open menu"
+          items={[{ id: 'one', label: 'One', onClick: () => undefined }]}
+          data={{ test: 'ref-dropdown' }}
+        />
+        <button
+          type="button"
+          data-test="focus-dropdown"
+          onClick={() => dropdownRef.current?.focus()}
+        >
+          Focus dropdown
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <MultiSelect
+          ref={multiSelectRef}
+          items={[
+            { value: 'one', label: 'One' },
+            { value: 'two', label: 'Two' },
+          ]}
+          value={multiValue}
+          onChange={setMultiValue}
+          ariaLabel="Multi-select"
+          data={{ test: 'ref-multi-select' }}
+        />
+        <button
+          type="button"
+          data-test="focus-multi-select"
+          onClick={() => multiSelectRef.current?.focus()}
+        >
+          Focus multi-select
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <SelectField
+          ref={selectFieldRef}
+          items={[
+            { value: 'one', label: 'One' },
+            { value: 'two', label: 'Two' },
+          ]}
+          value={selectValue}
+          onChange={setSelectValue}
+          placeholder="Select one"
+          data={{ test: 'ref-select-field' }}
+        />
+        <button
+          type="button"
+          data-test="focus-select-field"
+          onClick={() => selectFieldRef.current?.focus()}
+        >
+          Focus select field
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <AlphaNumericPinField
+          id="ref-pin"
+          ref={pinRef}
+          value={pinValue}
+          onChange={async (value) => setPinValue(value)}
+          length={4}
+          label="PIN"
+          data={{ test: 'ref-pin' }}
+        />
+        <button
+          type="button"
+          data-test="focus-pin"
+          onClick={() => pinRef.current?.focus()}
+        >
+          Focus PIN
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <ColorPicker
+          ref={colorPickerRef}
+          color={color}
+          onSubmit={setColor}
+          submitText="Save"
+          colorLabel="Color"
+          triggerAriaLabel="Pick a color"
+          dataTrigger={{ test: 'ref-color-picker' }}
+        />
+        <button
+          type="button"
+          data-test="focus-color-picker"
+          onClick={() => colorPickerRef.current?.focus()}
+        >
+          Focus color picker
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <DatePicker
+          ref={datePickerRef}
+          date={date}
+          onDateChange={setDate}
+          dataTrigger={{ test: 'ref-date-picker' }}
+        />
+        <button
+          type="button"
+          data-test="focus-date-picker"
+          onClick={() => datePickerRef.current?.focus()}
+        >
+          Focus date picker
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <DateRangePicker
+          ref={dateRangePickerRef}
+          range={range}
+          onRangeChange={setRange}
+          dataTrigger={{ test: 'ref-date-range-picker' }}
+        />
+        <button
+          type="button"
+          data-test="focus-date-range-picker"
+          onClick={() => dateRangePickerRef.current?.focus()}
+        >
+          Focus date range picker
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <DateTimePicker
+          ref={dateTimePickerRef}
+          weekStartsOn={1}
+          showWeekNumber={false}
+          showOutsideDays={false}
+          value={dateTime}
+          onChange={setDateTime}
+          dataTrigger={{ test: 'ref-date-time-picker' }}
+        />
+        <button
+          type="button"
+          data-test="focus-date-time-picker"
+          onClick={() => dateTimePickerRef.current?.focus()}
+        >
+          Focus date-time picker
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/design-system/src/CompositeRefs.stories.mdx
+++ b/packages/design-system/src/CompositeRefs.stories.mdx
@@ -38,6 +38,7 @@ export const Default = () => {
   const [switchChecked, setSwitchChecked] = useState(false)
   const [sliderValue, setSliderValue] = useState(5)
   const [collapsibleOpen, setCollapsibleOpen] = useState(false)
+  const [dropdownValue, setDropdownValue] = useState('')
   const [multiValue, setMultiValue] = useState([])
   const [selectValue, setSelectValue] = useState('')
   const [pinValue, setPinValue] = useState('')
@@ -85,6 +86,7 @@ export const Default = () => {
       <div className="flex items-center gap-2">
         <Slider
           ref={sliderRef}
+          ariaLabel="Slider"
           min={0}
           max={10}
           step={1}
@@ -126,9 +128,16 @@ export const Default = () => {
         <Dropdown
           ref={dropdownRef}
           trigger="Open menu"
-          items={[{ id: 'one', label: 'One', onClick: () => undefined }]}
+          items={[
+            {
+              id: 'one',
+              label: 'One',
+              onClick: () => setDropdownValue('One'),
+            },
+          ]}
           data={{ test: 'ref-dropdown' }}
         />
+        <output data-test="selected-dropdown">{dropdownValue}</output>
         <button
           type="button"
           data-test="focus-dropdown"
@@ -168,6 +177,7 @@ export const Default = () => {
           ]}
           value={selectValue}
           onChange={setSelectValue}
+          label="Select field"
           placeholder="Select one"
           data={{ test: 'ref-select-field' }}
         />
@@ -208,7 +218,9 @@ export const Default = () => {
           colorLabel="Color"
           triggerAriaLabel="Pick a color"
           dataTrigger={{ test: 'ref-color-picker' }}
+          dataSubmit={{ test: 'submit-color-picker' }}
         />
+        <output data-test="selected-color">{color}</output>
         <button
           type="button"
           data-test="focus-color-picker"

--- a/packages/design-system/src/DatePicker.tsx
+++ b/packages/design-system/src/DatePicker.tsx
@@ -22,6 +22,7 @@ export interface DatePickerClassName {
 
 export interface DatePickerProps {
   id?: string
+  ref?: React.Ref<HTMLButtonElement>
   date: Date | undefined
   onDateChange: Dispatch<SetStateAction<Date | undefined>>
   label?: string
@@ -84,6 +85,7 @@ export interface DatePickerProps {
  */
 export function DatePicker({
   id,
+  ref,
   date,
   onDateChange,
   label = '',
@@ -129,6 +131,7 @@ export function DatePicker({
         <div className="flex flex-row gap-2">
           <PopoverTrigger disabled={disabled} asChild>
             <Button
+              ref={ref}
               type="button"
               variant="outline"
               disabled={disabled}

--- a/packages/design-system/src/DateRangePicker.tsx
+++ b/packages/design-system/src/DateRangePicker.tsx
@@ -20,6 +20,7 @@ export interface DateRangePickerClassName {
 
 export interface DateRangePickerProps {
   id?: string
+  ref?: React.Ref<HTMLButtonElement>
   range: DateRange | undefined
   onRangeChange: (range: DateRange | undefined) => void
   label?: string
@@ -81,6 +82,7 @@ const DATE_FORMAT = 'DD.MM.YYYY'
  */
 export function DateRangePicker({
   id,
+  ref,
   range,
   onRangeChange,
   label = '',
@@ -125,6 +127,7 @@ export function DateRangePicker({
         <PopoverTrigger disabled={disabled} asChild>
           <Button
             id={id}
+            ref={ref}
             type="button"
             variant="outline"
             disabled={disabled}

--- a/packages/design-system/src/DatetimePicker.tsx
+++ b/packages/design-system/src/DatetimePicker.tsx
@@ -612,6 +612,7 @@ type DateTimePickerRef = HTMLButtonElement
  * This component provides a date and time picker with optional label, error handling, and customizable display and granularity.
  *
  * @param value - The currently selected date value.
+ * @param ref - A ref to the visible calendar trigger button.
  * @param onChange - Callback function called when the date value changes.
  * @param onMonthChange - Callback function called when the displayed month changes.
  * @param disabled - Whether the picker is disabled.

--- a/packages/design-system/src/DatetimePicker.tsx
+++ b/packages/design-system/src/DatetimePicker.tsx
@@ -8,7 +8,7 @@ import { enUS } from 'date-fns/locale'
 import dayjs from 'dayjs'
 import { Clock } from 'lucide-react'
 import * as React from 'react'
-import { useImperativeHandle, useRef } from 'react'
+import { useImperativeHandle } from 'react'
 import { DayPicker, DayPickerProps } from 'react-day-picker'
 import { twMerge } from 'tailwind-merge'
 import FormLabel from './FormLabel'
@@ -549,6 +549,7 @@ TimePicker.displayName = 'TimePicker'
 
 type Granularity = 'day' | 'hour' | 'minute' | 'second'
 type DateTimePickerProps = {
+  ref?: React.Ref<HTMLButtonElement>
   value?: Date
   onChange?: (date: Date | undefined) => void
   onMonthChange?: (date: Date | undefined) => void
@@ -605,9 +606,7 @@ type DateTimePickerProps = {
   'locale' | 'weekStartsOn' | 'showWeekNumber' | 'showOutsideDays'
 >
 
-type DateTimePickerRef = {
-  value?: Date
-} & Omit<HTMLButtonElement, 'value'>
+type DateTimePickerRef = HTMLButtonElement
 
 /**
  * This component provides a date and time picker with optional label, error handling, and customizable display and granularity.
@@ -645,261 +644,242 @@ type DateTimePickerRef = {
  * @param showOutsideDays - Whether to show days from adjacent months in the calendar.
  * @returns Date and time picker component with optional label, error display, and customizable granularity and formatting.
  */
-const DateTimePicker = React.forwardRef<
-  Partial<DateTimePickerRef>,
-  DateTimePickerProps
->(
-  (
-    {
-      locale = enUS,
-      defaultPopupValue = new Date(new Date().setHours(0, 0, 0, 0)),
-      value,
-      onChange,
-      onMonthChange,
-      hourCycle = 24,
-      disabled = false,
-      displayFormat,
-      granularity = 'second',
-      placeholder = 'Pick a date',
-      error,
-      hideError,
-      isTouched,
-      className,
-      label,
-      labelType = 'small',
-      align = 'start',
-      captionLayout = 'dropdown',
-      required = false,
-      tooltip,
-      ...props
-    },
-    ref
-  ) => {
-    const [month, setMonth] = React.useState<Date>(value ?? defaultPopupValue)
-    const buttonRef = useRef<HTMLButtonElement>(null)
-    const [displayDate, setDisplayDate] = React.useState<Date | undefined>(
-      value ?? undefined
-    )
-    const useSplitTrigger = Boolean(
-      displayDate && !displayFormat && granularity !== 'day'
-    )
-    const triggerDateLabel = displayDate
-      ? dayjs(displayDate).format(
-          useSplitTrigger ? 'DD.MM.YYYY' : (displayFormat ?? 'DD.MM.YYYY')
-        )
-      : placeholder
-    const triggerTimeLabel = displayDate
-      ? dayjs(displayDate).format('HH:mm')
-      : ''
+const DateTimePicker = ({
+  locale = enUS,
+  defaultPopupValue = new Date(new Date().setHours(0, 0, 0, 0)),
+  value,
+  onChange,
+  onMonthChange,
+  hourCycle = 24,
+  disabled = false,
+  displayFormat,
+  granularity = 'second',
+  placeholder = 'Pick a date',
+  error,
+  hideError,
+  isTouched,
+  className,
+  label,
+  labelType = 'small',
+  align = 'start',
+  captionLayout = 'dropdown',
+  required = false,
+  tooltip,
+  ref,
+  ...props
+}: DateTimePickerProps) => {
+  const [month, setMonth] = React.useState<Date>(value ?? defaultPopupValue)
+  const [displayDate, setDisplayDate] = React.useState<Date | undefined>(
+    value ?? undefined
+  )
+  const useSplitTrigger = Boolean(
+    displayDate && !displayFormat && granularity !== 'day'
+  )
+  const triggerDateLabel = displayDate
+    ? dayjs(displayDate).format(
+        useSplitTrigger ? 'DD.MM.YYYY' : (displayFormat ?? 'DD.MM.YYYY')
+      )
+    : placeholder
+  const triggerTimeLabel = displayDate ? dayjs(displayDate).format('HH:mm') : ''
 
-    /**
-     * Makes sure display date updates when value change on
-     * parent component
-     */
-    React.useEffect(() => {
-      setDisplayDate(value)
-    }, [value])
+  /**
+   * Makes sure display date updates when value change on
+   * parent component
+   */
+  React.useEffect(() => {
+    setDisplayDate(value)
+  }, [value])
 
-    /**
-     * carry over the current time when a user clicks a new day
-     * instead of resetting to 00:00
-     */
-    const handleMonthChange = (newDay: Date | undefined) => {
-      if (!newDay) {
-        return
-      }
-      if (!defaultPopupValue) {
-        newDay.setHours(
-          month?.getHours() ?? 0,
-          month?.getMinutes() ?? 0,
-          month?.getSeconds() ?? 0
-        )
-        onMonthChange?.(newDay)
-        setMonth(newDay)
-        return
-      }
-      const diff = newDay.getTime() - defaultPopupValue.getTime()
-      const diffInDays = diff / (1000 * 60 * 60 * 24)
-      const newDateFull = add(defaultPopupValue, {
-        days: Math.ceil(diffInDays),
-      })
-      newDateFull.setHours(
+  /**
+   * carry over the current time when a user clicks a new day
+   * instead of resetting to 00:00
+   */
+  const handleMonthChange = (newDay: Date | undefined) => {
+    if (!newDay) {
+      return
+    }
+    if (!defaultPopupValue) {
+      newDay.setHours(
         month?.getHours() ?? 0,
         month?.getMinutes() ?? 0,
         month?.getSeconds() ?? 0
       )
-      onMonthChange?.(newDateFull)
-      setMonth(newDateFull)
-    }
-
-    const onSelect = (newDay?: Date) => {
-      if (!newDay) {
-        return
-      }
-      onChange?.(newDay)
+      onMonthChange?.(newDay)
       setMonth(newDay)
-      setDisplayDate(newDay)
+      return
     }
-
-    useImperativeHandle(
-      ref,
-      () => ({
-        ...buttonRef.current,
-        value: displayDate,
-      }),
-      [displayDate]
+    const diff = newDay.getTime() - defaultPopupValue.getTime()
+    const diffInDays = diff / (1000 * 60 * 60 * 24)
+    const newDateFull = add(defaultPopupValue, {
+      days: Math.ceil(diffInDays),
+    })
+    newDateFull.setHours(
+      month?.getHours() ?? 0,
+      month?.getMinutes() ?? 0,
+      month?.getSeconds() ?? 0
     )
-
-    return (
-      <Popover>
-        <div
-          className={twMerge(
-            'flex w-[280px] flex-row',
-            labelType === 'small' && 'flex-col',
-            className?.trigger
-          )}
-        >
-          {label && (
-            <FormLabel
-              required={required}
-              label={label}
-              labelType={labelType}
-              tooltip={tooltip}
-              className={{
-                label: className?.label,
-                tooltip: className?.tooltip,
-              }}
-            />
-          )}
-          <div className="flex flex-row gap-2">
-            <PopoverTrigger asChild disabled={disabled}>
-              <Button
-                variant="outline"
-                type="button"
-                disabled={disabled}
-                className={cn(
-                  'h-10 min-w-[220px] justify-start overflow-hidden rounded-md border-[#E0E0E0] px-0 text-left text-sm font-normal text-[#111111] hover:bg-[#FAFAFA]',
-                  !displayDate && 'px-3 text-[#666666]',
-                  !!error &&
-                    isTouched &&
-                    'border-destructive bg-destructive-background',
-                  className?.input
-                )}
-                ref={buttonRef}
-                data-cy={props.dataTrigger?.cy}
-                data-test={props.dataTrigger?.test}
-              >
-                <FontAwesomeIcon
-                  icon={faCalendar}
-                  className={cn(
-                    'h-4 w-4 text-[#666666]',
-                    displayDate ? 'mr-2.5 ml-3' : 'mr-2.5'
-                  )}
-                />
-                {displayDate ? (
-                  <>
-                    <span>{triggerDateLabel}</span>
-                    {useSplitTrigger && (
-                      <>
-                        <span
-                          aria-hidden="true"
-                          className="mx-3 h-10 w-px bg-[#E0E0E0]"
-                        />
-                        <Clock className="mr-2 h-4 w-4 text-[#666666]" />
-                        <span className="pr-3 font-mono text-sm tabular-nums">
-                          {triggerTimeLabel}
-                        </span>
-                      </>
-                    )}
-                  </>
-                ) : (
-                  <span>{triggerDateLabel}</span>
-                )}
-              </Button>
-            </PopoverTrigger>
-            {error && !hideError && isTouched && (
-              <Tooltip
-                tooltip={error}
-                ariaLabel={error}
-                delay={0}
-                className={{
-                  tooltip: twMerge('max-w-120 text-sm', className?.error),
-                }}
-              >
-                <FontAwesomeIcon
-                  icon={faCircleExclamation}
-                  className="text-destructive-text mr-1"
-                />
-              </Tooltip>
-            )}
-          </div>
-        </div>
-        <PopoverContent
-          className="w-auto border-none bg-transparent p-0 shadow-none"
-          align={align}
-        >
-          <div
-            className={cn(
-              'w-fit',
-              granularity !== 'day' &&
-                'overflow-hidden rounded-lg border border-[#E0E0E0] bg-white shadow-lg'
-            )}
-          >
-            <Calendar
-              mode="single"
-              captionLayout={captionLayout}
-              disabled={disabled}
-              selected={displayDate}
-              month={month}
-              onSelect={(newDate) => {
-                if (newDate) {
-                  newDate.setHours(
-                    month?.getHours() ?? 0,
-                    month?.getMinutes() ?? 0,
-                    month?.getSeconds() ?? 0
-                  )
-                  onSelect(newDate)
-                }
-              }}
-              onMonthChange={handleMonthChange}
-              locale={locale}
-              dataNextMonth={props.dataNextMonth}
-              dataPreviousMonth={props.dataPreviousMonth}
-              data-cy={props.dataCalendar?.cy}
-              data-test={props.dataCalendar?.test}
-              className={
-                granularity !== 'day'
-                  ? 'rounded-none border-0 shadow-none'
-                  : undefined
-              }
-              {...props}
-            />
-            {granularity !== 'day' && (
-              <div className="border-t border-[#E0E0E0] bg-white p-3">
-                <TimePicker
-                  disabled={disabled}
-                  onChange={(value) => {
-                    onChange?.(value)
-                    setDisplayDate(value)
-                    if (value) {
-                      setMonth(value)
-                    }
-                  }}
-                  date={month}
-                  hourCycle={hourCycle}
-                  granularity={granularity}
-                  dataHours={props.dataHours}
-                  dataMinutes={props.dataMinutes}
-                  dataSeconds={props.dataSeconds}
-                />
-              </div>
-            )}
-          </div>
-        </PopoverContent>
-      </Popover>
-    )
+    onMonthChange?.(newDateFull)
+    setMonth(newDateFull)
   }
-)
+
+  const onSelect = (newDay?: Date) => {
+    if (!newDay) {
+      return
+    }
+    onChange?.(newDay)
+    setMonth(newDay)
+    setDisplayDate(newDay)
+  }
+
+  return (
+    <Popover>
+      <div
+        className={twMerge(
+          'flex w-[280px] flex-row',
+          labelType === 'small' && 'flex-col',
+          className?.trigger
+        )}
+      >
+        {label && (
+          <FormLabel
+            required={required}
+            label={label}
+            labelType={labelType}
+            tooltip={tooltip}
+            className={{
+              label: className?.label,
+              tooltip: className?.tooltip,
+            }}
+          />
+        )}
+        <div className="flex flex-row gap-2">
+          <PopoverTrigger asChild disabled={disabled}>
+            <Button
+              variant="outline"
+              type="button"
+              disabled={disabled}
+              className={cn(
+                'h-10 min-w-[220px] justify-start overflow-hidden rounded-md border-[#E0E0E0] px-0 text-left text-sm font-normal text-[#111111] hover:bg-[#FAFAFA]',
+                !displayDate && 'px-3 text-[#666666]',
+                !!error &&
+                  isTouched &&
+                  'border-destructive bg-destructive-background',
+                className?.input
+              )}
+              ref={ref}
+              data-cy={props.dataTrigger?.cy}
+              data-test={props.dataTrigger?.test}
+            >
+              <FontAwesomeIcon
+                icon={faCalendar}
+                className={cn(
+                  'h-4 w-4 text-[#666666]',
+                  displayDate ? 'mr-2.5 ml-3' : 'mr-2.5'
+                )}
+              />
+              {displayDate ? (
+                <>
+                  <span>{triggerDateLabel}</span>
+                  {useSplitTrigger && (
+                    <>
+                      <span
+                        aria-hidden="true"
+                        className="mx-3 h-10 w-px bg-[#E0E0E0]"
+                      />
+                      <Clock className="mr-2 h-4 w-4 text-[#666666]" />
+                      <span className="pr-3 font-mono text-sm tabular-nums">
+                        {triggerTimeLabel}
+                      </span>
+                    </>
+                  )}
+                </>
+              ) : (
+                <span>{triggerDateLabel}</span>
+              )}
+            </Button>
+          </PopoverTrigger>
+          {error && !hideError && isTouched && (
+            <Tooltip
+              tooltip={error}
+              ariaLabel={error}
+              delay={0}
+              className={{
+                tooltip: twMerge('max-w-120 text-sm', className?.error),
+              }}
+            >
+              <FontAwesomeIcon
+                icon={faCircleExclamation}
+                className="text-destructive-text mr-1"
+              />
+            </Tooltip>
+          )}
+        </div>
+      </div>
+      <PopoverContent
+        className="w-auto border-none bg-transparent p-0 shadow-none"
+        align={align}
+      >
+        <div
+          className={cn(
+            'w-fit',
+            granularity !== 'day' &&
+              'overflow-hidden rounded-lg border border-[#E0E0E0] bg-white shadow-lg'
+          )}
+        >
+          <Calendar
+            mode="single"
+            captionLayout={captionLayout}
+            disabled={disabled}
+            selected={displayDate}
+            month={month}
+            onSelect={(newDate) => {
+              if (newDate) {
+                newDate.setHours(
+                  month?.getHours() ?? 0,
+                  month?.getMinutes() ?? 0,
+                  month?.getSeconds() ?? 0
+                )
+                onSelect(newDate)
+              }
+            }}
+            onMonthChange={handleMonthChange}
+            locale={locale}
+            dataNextMonth={props.dataNextMonth}
+            dataPreviousMonth={props.dataPreviousMonth}
+            data-cy={props.dataCalendar?.cy}
+            data-test={props.dataCalendar?.test}
+            className={
+              granularity !== 'day'
+                ? 'rounded-none border-0 shadow-none'
+                : undefined
+            }
+            {...props}
+          />
+          {granularity !== 'day' && (
+            <div className="border-t border-[#E0E0E0] bg-white p-3">
+              <TimePicker
+                disabled={disabled}
+                onChange={(value) => {
+                  onChange?.(value)
+                  setDisplayDate(value)
+                  if (value) {
+                    setMonth(value)
+                  }
+                }}
+                date={month}
+                hourCycle={hourCycle}
+                granularity={granularity}
+                dataHours={props.dataHours}
+                dataMinutes={props.dataMinutes}
+                dataSeconds={props.dataSeconds}
+              />
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
 
 DateTimePicker.displayName = 'DateTimePicker'
 

--- a/packages/design-system/src/Dropdown.tsx
+++ b/packages/design-system/src/Dropdown.tsx
@@ -97,6 +97,7 @@ type Item =
 
 interface DropdownProps {
   id?: string
+  ref?: React.Ref<HTMLButtonElement>
   disabled?: boolean
   trigger: string | React.ReactNode
   items?: Item[]
@@ -138,6 +139,7 @@ export interface DropdownWithGroupsProps extends DropdownProps {
  */
 export function Dropdown({
   id,
+  ref,
   disabled = false,
   trigger,
   items,
@@ -150,9 +152,10 @@ export function Dropdown({
     <DropdownMenu>
       <DropdownMenuTrigger
         id={id}
+        ref={ref}
         disabled={disabled}
         className={twMerge(
-          'border-input bg-background ring-offset-background hover:bg-accent hover:text-accent-foreground focus-visible:ring-ring inline-flex h-max items-center justify-center rounded-md border px-3 py-1.5 text-sm font-medium whitespace-normal transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 data-disabled:bg-white',
+          'border-input bg-background ring-offset-background hover:bg-accent hover:text-accent-foreground focus-visible:ring-ring focus-visible:outline-hidden data-disabled:bg-white inline-flex h-max items-center justify-center whitespace-normal rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
           className?.trigger
         )}
         data-cy={data?.cy}

--- a/packages/design-system/src/Dropdown.tsx
+++ b/packages/design-system/src/Dropdown.tsx
@@ -155,7 +155,7 @@ export function Dropdown({
         ref={ref}
         disabled={disabled}
         className={twMerge(
-          'border-input bg-background ring-offset-background hover:bg-accent hover:text-accent-foreground focus-visible:ring-ring focus-visible:outline-hidden data-disabled:bg-white inline-flex h-max items-center justify-center whitespace-normal rounded-md border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'border-input bg-background ring-offset-background hover:bg-accent hover:text-accent-foreground focus-visible:ring-ring inline-flex h-max items-center justify-center rounded-md border px-3 py-1.5 text-sm font-medium whitespace-normal transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 data-disabled:bg-white',
           className?.trigger
         )}
         data-cy={data?.cy}

--- a/packages/design-system/src/MultiSelect.tsx
+++ b/packages/design-system/src/MultiSelect.tsx
@@ -34,6 +34,7 @@ export interface MultiSelectClassName {
 
 export interface MultiSelectProps {
   id?: string
+  ref?: React.Ref<HTMLButtonElement>
   items: MultiSelectItem[]
   value: string[]
   onChange: (newValue: string[]) => void
@@ -71,6 +72,7 @@ export interface MultiSelectProps {
  */
 export function MultiSelect({
   id,
+  ref,
   items,
   value,
   onChange,
@@ -100,6 +102,7 @@ export function MultiSelect({
         <PopoverTrigger asChild>
           <Button
             id={id}
+            ref={ref}
             type="button"
             variant="outline"
             aria-haspopup="listbox"
@@ -165,7 +168,7 @@ export function MultiSelect({
             <span
               key={item.value}
               className={twMerge(
-                'bg-primary-20 text-primary-100 inline-flex items-center gap-1 rounded-md py-0.5 pr-1 pl-2 text-sm',
+                'bg-primary-20 text-primary-100 inline-flex items-center gap-1 rounded-md py-0.5 pl-2 pr-1 text-sm',
                 className?.chip
               )}
             >

--- a/packages/design-system/src/MultiSelect.tsx
+++ b/packages/design-system/src/MultiSelect.tsx
@@ -168,7 +168,7 @@ export function MultiSelect({
             <span
               key={item.value}
               className={twMerge(
-                'bg-primary-20 text-primary-100 inline-flex items-center gap-1 rounded-md py-0.5 pl-2 pr-1 text-sm',
+                'bg-primary-20 text-primary-100 inline-flex items-center gap-1 rounded-md py-0.5 pr-1 pl-2 text-sm',
                 className?.chip
               )}
             >

--- a/packages/design-system/src/Slider.tsx
+++ b/packages/design-system/src/Slider.tsx
@@ -6,6 +6,7 @@ import { twMerge } from 'tailwind-merge'
 
 interface SliderProps {
   id?: string
+  ref?: React.Ref<HTMLSpanElement>
   value?: number
   handleChange: (newValue: number) => void
   defaultValue?: number
@@ -74,6 +75,7 @@ export interface SliderWithIconsProps extends SliderProps {
  */
 export function Slider({
   id,
+  ref,
   value,
   labels,
   handleChange,
@@ -104,7 +106,7 @@ export function Slider({
         data-cy={data?.cy}
         data-test={data?.test}
         className={twMerge(
-          'relative flex w-full items-center select-none',
+          'relative flex w-full select-none items-center',
           compact ? 'h-4' : 'h-[18px]',
           className?.root
         )}
@@ -137,8 +139,9 @@ export function Slider({
         </RadixSlider.Track>
 
         <RadixSlider.Thumb
+          ref={ref}
           className={twMerge(
-            'focus:ring-ring/50 flex size-[18px] flex-col items-center justify-center rounded-full border-2 border-solid bg-white shadow-sm transition-[color,box-shadow] focus:ring-[3px] focus:outline-hidden',
+            'focus:ring-ring/50 focus:outline-hidden flex size-[18px] flex-col items-center justify-center rounded-full border-2 border-solid bg-white shadow-sm transition-[color,box-shadow] focus:ring-[3px]',
             compact && 'size-4 border-[1.5px]',
             disabled ? 'cursor-not-allowed' : 'cursor-move',
             disabled && compact ? 'bg-gray-100' : 'bg-white',

--- a/packages/design-system/src/Slider.tsx
+++ b/packages/design-system/src/Slider.tsx
@@ -109,7 +109,7 @@ export function Slider({
         data-cy={data?.cy}
         data-test={data?.test}
         className={twMerge(
-          'relative flex w-full select-none items-center',
+          'relative flex w-full items-center select-none',
           compact ? 'h-4' : 'h-[18px]',
           className?.root
         )}
@@ -145,7 +145,7 @@ export function Slider({
           ref={ref}
           aria-label={ariaLabel}
           className={twMerge(
-            'focus:ring-ring/50 focus:outline-hidden flex size-[18px] flex-col items-center justify-center rounded-full border-2 border-solid bg-white shadow-sm transition-[color,box-shadow] focus:ring-[3px]',
+            'focus:ring-ring/50 flex size-[18px] flex-col items-center justify-center rounded-full border-2 border-solid bg-white shadow-sm transition-[color,box-shadow] focus:ring-[3px] focus:outline-hidden',
             compact && 'size-4 border-[1.5px]',
             disabled ? 'cursor-not-allowed' : 'cursor-move',
             disabled && compact ? 'bg-gray-100' : 'bg-white',

--- a/packages/design-system/src/Slider.tsx
+++ b/packages/design-system/src/Slider.tsx
@@ -7,6 +7,7 @@ import { twMerge } from 'tailwind-merge'
 interface SliderProps {
   id?: string
   ref?: React.Ref<HTMLSpanElement>
+  ariaLabel?: string
   value?: number
   handleChange: (newValue: number) => void
   defaultValue?: number
@@ -57,6 +58,7 @@ export interface SliderWithIconsProps extends SliderProps {
  * This function returns a pre-styled Slider component based on the RadixUI slider component and the custom theme.
  *
  * @param id - The id of the slider.
+ * @param ariaLabel - Accessible name for the slider thumb.
  * @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy)
  * @param value - The value of the slider. The value should be between the min and max value and is maintained by the parent component.
  * @param defaultValue - The default value of the slider, if the value is undefined
@@ -76,6 +78,7 @@ export interface SliderWithIconsProps extends SliderProps {
 export function Slider({
   id,
   ref,
+  ariaLabel,
   value,
   labels,
   handleChange,
@@ -140,6 +143,7 @@ export function Slider({
 
         <RadixSlider.Thumb
           ref={ref}
+          aria-label={ariaLabel}
           className={twMerge(
             'focus:ring-ring/50 focus:outline-hidden flex size-[18px] flex-col items-center justify-center rounded-full border-2 border-solid bg-white shadow-sm transition-[color,box-shadow] focus:ring-[3px]',
             compact && 'size-4 border-[1.5px]',

--- a/packages/design-system/src/Switch.tsx
+++ b/packages/design-system/src/Switch.tsx
@@ -18,6 +18,7 @@ export interface SwitchClassName {
 
 export interface SwitchProps {
   id?: string
+  ref?: React.Ref<HTMLButtonElement>
   data?: {
     cy?: string
     test?: string
@@ -62,6 +63,7 @@ export interface SwitchProps {
  */
 export function Switch({
   id,
+  ref,
   data,
   disabled = false,
   label,
@@ -129,6 +131,7 @@ export function Switch({
       )}
       <RadixSwitch.Root
         id={inputId}
+        ref={ref}
         aria-label={!label ? ariaLabel : undefined}
         data-cy={data?.cy}
         data-test={data?.test}

--- a/packages/design-system/src/Table.stories.mdx
+++ b/packages/design-system/src/Table.stories.mdx
@@ -29,7 +29,6 @@ The Table component accepts the following props:
 - @param caption - The optional caption of the table.
 - @param ref - The optional ref object allows you to access the table methods.
 - @param className - The optional className object allows you to override the default styling.
-- @param forwardedRef - The optional forwardedRef object allows you to access table methods from the parent component.
 - @param emptyCellText - The optional emptyCellText allows you to define the text that should be displayed in empty cells.
 - @param defaultSortField - The optional defaultSortField allows you to define the default sorting field.
 - @param defaultSortOrder - The optional defaultSortOrder allows you to define the default sorting order.
@@ -71,7 +70,6 @@ Props (Table component):
   body?: string,
   row?: string
   } - Styling overrides for table parts
-- forwardedRef?: React.Ref - Alternative ref prop for parent access
 - emptyCellText?: string - Text to show in empty cells (default: '-')
 - defaultSortField?: string - Initial column to sort by
 - defaultSortOrder?: 'asc' | 'desc' - Initial sort direction
@@ -281,8 +279,9 @@ return (
     className={{ root: 'mb-4' }}
   />
   <Button
+    data={{ test: 'reset-table' }}
     onClick={() => {
-      ref.current.reset()
+      ref.current?.reset()
     }}
   >
     Reset Table Filters
@@ -301,7 +300,7 @@ return (
     ]}
     data={data}
     caption="Table with example data"
-    forwardedRef={ref}
+    ref={ref}
   />
 </>
 ) }

--- a/packages/design-system/src/Table.tsx
+++ b/packages/design-system/src/Table.tsx
@@ -9,6 +9,10 @@ type BaseRowType = {
   className?: string
 }
 
+export interface TableRef {
+  reset(): void
+}
+
 export type ColumnType<RowType> = {
   className?: string
   label: string
@@ -45,7 +49,7 @@ export interface TableProps<RowType extends BaseRowType> {
     body?: string
     row?: string
   }
-  forwardedRef?: React.Ref<unknown>
+  ref?: React.Ref<TableRef>
   emptyCellText?: string
   defaultSortField?: string
   defaultSortOrder?: 'asc' | 'desc'
@@ -64,7 +68,6 @@ export interface TableProps<RowType extends BaseRowType> {
  * @param caption - The optional caption of the table.
  * @param ref - The optional ref object allows you to access the table methods.
  * @param className - The optional className object allows you to override the default styling.
- * @param forwardedRef - The optional forwardedRef object allows you to access table methods from the parent component.
  * @param emptyCellText - The optional emptyCellText allows you to define the text that should be displayed in empty cells.
  * @param defaultSortField - The optional defaultSortField allows you to define the default sorting field.
  * @param defaultSortOrder - The optional defaultSortOrder allows you to define the default sorting order.
@@ -79,7 +82,7 @@ export function Table<
   data,
   caption,
   className,
-  forwardedRef,
+  ref,
   emptyCellText = '——',
   defaultSortField,
   defaultSortOrder = 'asc',
@@ -89,7 +92,7 @@ export function Table<
   )
   const [order, setOrder] = useState<'asc' | 'desc'>(defaultSortOrder)
 
-  useImperativeHandle(forwardedRef, () => {
+  useImperativeHandle(ref, () => {
     return {
       reset() {
         setSortField(defaultSortField)
@@ -208,7 +211,7 @@ export function Table<
                   scope="col"
                   aria-sort={col.sortable ? sortAriaValue : undefined}
                   className={twMerge(
-                    'border-border bg-muted text-foreground border-b text-start text-xs font-semibold tracking-[0.06em] whitespace-nowrap uppercase',
+                    'border-border bg-muted text-foreground whitespace-nowrap border-b text-start text-xs font-semibold uppercase tracking-[0.06em]',
                     !col.sortable && 'px-4 py-3',
                     className?.tableHeader,
                     col.className
@@ -218,7 +221,7 @@ export function Table<
                     <button
                       type="button"
                       onClick={() => handleSortingChange(col.accessor)}
-                      className="focus-visible:ring-ring flex w-full cursor-pointer items-center px-4 py-3 text-start focus-visible:ring-2 focus-visible:outline-hidden focus-visible:ring-inset"
+                      className="focus-visible:ring-ring focus-visible:outline-hidden flex w-full cursor-pointer items-center px-4 py-3 text-start focus-visible:ring-2 focus-visible:ring-inset"
                     >
                       <FontAwesomeIcon
                         className={twMerge(

--- a/packages/design-system/src/Table.tsx
+++ b/packages/design-system/src/Table.tsx
@@ -211,7 +211,7 @@ export function Table<
                   scope="col"
                   aria-sort={col.sortable ? sortAriaValue : undefined}
                   className={twMerge(
-                    'border-border bg-muted text-foreground whitespace-nowrap border-b text-start text-xs font-semibold uppercase tracking-[0.06em]',
+                    'border-border bg-muted text-foreground border-b text-start text-xs font-semibold tracking-[0.06em] whitespace-nowrap uppercase',
                     !col.sortable && 'px-4 py-3',
                     className?.tableHeader,
                     col.className
@@ -221,7 +221,7 @@ export function Table<
                     <button
                       type="button"
                       onClick={() => handleSortingChange(col.accessor)}
-                      className="focus-visible:ring-ring focus-visible:outline-hidden flex w-full cursor-pointer items-center px-4 py-3 text-start focus-visible:ring-2 focus-visible:ring-inset"
+                      className="focus-visible:ring-ring flex w-full cursor-pointer items-center px-4 py-3 text-start focus-visible:ring-2 focus-visible:outline-hidden focus-visible:ring-inset"
                     >
                       <FontAwesomeIcon
                         className={twMerge(

--- a/packages/design-system/src/forms/AlphaNumericPinField.tsx
+++ b/packages/design-system/src/forms/AlphaNumericPinField.tsx
@@ -17,6 +17,7 @@ export interface AlphaNumericPinFieldClassName {
 
 export interface AlphaNumericPinFieldProps {
   id?: string
+  ref?: React.Ref<HTMLInputElement>
   value: string
   onChange: (newValue: string) => Promise<void>
   length: number
@@ -54,6 +55,7 @@ export interface AlphaNumericPinFieldProps {
  */
 export function AlphaNumericPinField({
   id,
+  ref,
   value,
   onChange,
   length,
@@ -96,6 +98,7 @@ export function AlphaNumericPinField({
       <div className="flex w-full flex-row items-center gap-2">
         <InputOTP
           id={inputId}
+          ref={ref}
           aria-required={required || undefined}
           aria-describedby={visibleError ? errorId : undefined}
           maxLength={length}

--- a/packages/design-system/src/forms/SelectField.tsx
+++ b/packages/design-system/src/forms/SelectField.tsx
@@ -9,6 +9,7 @@ import { useFieldError } from './useFieldError'
 
 interface SelectFieldProps {
   id?: string
+  ref?: React.Ref<HTMLButtonElement>
   data?: {
     cy?: string
     test?: string
@@ -71,6 +72,7 @@ export interface SelectFieldGroupsProps extends SelectFieldProps {
  */
 export function SelectField({
   id,
+  ref,
   data,
   name,
   items,
@@ -120,6 +122,7 @@ export function SelectField({
         <div className="flex flex-row items-center gap-2">
           <Select
             id={inputId}
+            ref={ref}
             ariaRequired={required}
             ariaDescribedBy={visibleError ? errorId : undefined}
             data={data}

--- a/packages/design-system/tests/contracts/composite-refs.spec.ts
+++ b/packages/design-system/tests/contracts/composite-refs.spec.ts
@@ -35,6 +35,7 @@ test.describe('composite ref contracts', () => {
     await gotoStory(page, story)
 
     const cases = [
+      'ref-collapsible',
       'ref-dropdown',
       'ref-multi-select',
       'ref-select-field',
@@ -49,10 +50,77 @@ test.describe('composite ref contracts', () => {
       await expect(trigger).toBeFocused()
       await page.keyboard.press('Enter')
       await expect(trigger).toHaveAttribute('aria-expanded', 'true')
-      await page.keyboard.press('Escape')
+      await page.keyboard.press(
+        target === 'ref-collapsible' ? 'Enter' : 'Escape'
+      )
       await expect(trigger).toHaveAttribute('aria-expanded', 'false')
       await expect(trigger).toBeFocused()
     }
+
+    const colorTrigger = page.locator('[data-test="ref-color-picker"]')
+    await colorTrigger.focus()
+    await page.keyboard.press('Enter')
+    await expect(colorTrigger).toHaveAttribute('aria-expanded', 'true')
+    await page.keyboard.press('Escape')
+    await expect(colorTrigger).toHaveAttribute('aria-expanded', 'false')
+    await expect(colorTrigger).toBeFocused()
+  })
+
+  test('preserves stateful selections and focus return', async ({ page }) => {
+    await gotoStory(page, story)
+
+    const dropdownTrigger = page.locator('[data-test="ref-dropdown"]')
+    await dropdownTrigger.click()
+    await page.getByRole('menuitem', { name: 'One' }).click()
+    await expect(page.locator('[data-test="selected-dropdown"]')).toHaveText(
+      'One'
+    )
+    await expect(dropdownTrigger).toBeFocused()
+
+    const multiSelectTrigger = page.locator('[data-test="ref-multi-select"]')
+    await multiSelectTrigger.click()
+    await page.getByRole('option', { name: 'One' }).click()
+    await expect(multiSelectTrigger).toContainText('1 selected')
+    await page.keyboard.press('Escape')
+    await expect(multiSelectTrigger).toBeFocused()
+
+    const selectTrigger = page.locator('[data-test="ref-select-field"]')
+    await selectTrigger.click()
+    await page.getByRole('option', { name: 'One' }).click()
+    await expect(selectTrigger).toContainText('One')
+    await expect(selectTrigger).toHaveAttribute('aria-expanded', 'false')
+    await expect(selectTrigger).toBeFocused()
+
+    const dateCases = [
+      ['ref-date-picker', 'Pick a date'],
+      ['ref-date-range-picker', 'Pick a date range'],
+      ['ref-date-time-picker', 'Pick a date'],
+    ] as const
+
+    for (const [target, placeholder] of dateCases) {
+      const trigger = page.locator(`[data-test="${target}"]`)
+      await trigger.click()
+      const dayButtons = page.locator(
+        '[data-slot="calendar"] button[data-day]:not([disabled])'
+      )
+      await dayButtons.first().click()
+      if (target === 'ref-date-range-picker') {
+        await dayButtons.nth(1).click()
+      }
+      await expect(trigger).not.toContainText(placeholder)
+      await page.keyboard.press('Escape')
+      await expect(trigger).toBeFocused()
+    }
+
+    const colorTrigger = page.locator('[data-test="ref-color-picker"]')
+    await colorTrigger.click()
+    const dialog = page.getByRole('dialog', { name: 'Pick a color' })
+    await dialog.getByRole('button', { name: 'Preset color #016272' }).click()
+    await dialog.locator('[data-test="submit-color-picker"]').click()
+    await expect(page.locator('[data-test="selected-color"]')).toHaveText(
+      '#016272'
+    )
+    await expect(colorTrigger).toBeFocused()
   })
 
   test('resets Table sorting through the imperative ref', async ({ page }) => {

--- a/packages/design-system/tests/contracts/composite-refs.spec.ts
+++ b/packages/design-system/tests/contracts/composite-refs.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test'
+
+import { gotoStory } from '../_support/ladle'
+
+const story = 'composite-refs--default'
+
+test.describe('composite ref contracts', () => {
+  test('focuses every public composite target', async ({ page }) => {
+    await gotoStory(page, story)
+
+    const cases = [
+      ['focus-checkbox', '[data-test="ref-checkbox"]'],
+      ['focus-switch', '[data-test="ref-switch"]'],
+      ['focus-slider', '[data-test="ref-slider"]'],
+      ['focus-collapsible', '[data-test="ref-collapsible"]'],
+      ['focus-dropdown', '[data-test="ref-dropdown"]'],
+      ['focus-multi-select', '[data-test="ref-multi-select"]'],
+      ['focus-select-field', '[data-test="ref-select-field"]'],
+      ['focus-pin', '#ref-pin'],
+      ['focus-color-picker', '[data-test="ref-color-picker"]'],
+      ['focus-date-picker', '[data-test="ref-date-picker"]'],
+      ['focus-date-range-picker', '[data-test="ref-date-range-picker"]'],
+      ['focus-date-time-picker', '[data-test="ref-date-time-picker"]'],
+    ] as const
+
+    for (const [action, target] of cases) {
+      await page.locator(`[data-test="${action}"]`).click()
+      await expect(page.locator(target)).toBeFocused()
+    }
+  })
+
+  test('keeps stateful trigger focus and dismissal behavior intact', async ({
+    page,
+  }) => {
+    await gotoStory(page, story)
+
+    const cases = [
+      'ref-dropdown',
+      'ref-multi-select',
+      'ref-select-field',
+      'ref-date-picker',
+      'ref-date-range-picker',
+      'ref-date-time-picker',
+    ] as const
+
+    for (const target of cases) {
+      const trigger = page.locator(`[data-test="${target}"]`)
+      await trigger.focus()
+      await expect(trigger).toBeFocused()
+      await page.keyboard.press('Enter')
+      await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+      await page.keyboard.press('Escape')
+      await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+      await expect(trigger).toBeFocused()
+    }
+  })
+
+  test('resets Table sorting through the imperative ref', async ({ page }) => {
+    await gotoStory(page, 'table--reset-table')
+
+    const countHeader = page.getByRole('columnheader', { name: 'Count' })
+    const countButton = page.getByRole('button', { name: 'Count' })
+    await expect(countHeader).toHaveAttribute('aria-sort', 'none')
+
+    await countButton.click()
+    await expect(countHeader).toHaveAttribute('aria-sort', 'ascending')
+
+    await page.locator('[data-test="reset-table"]').click()
+    await expect(countHeader).toHaveAttribute('aria-sort', 'none')
+  })
+})

--- a/packages/design-system/tests/contracts/composite-refs.types.ts
+++ b/packages/design-system/tests/contracts/composite-refs.types.ts
@@ -6,6 +6,7 @@ import type {
   DatePickerProps,
   DateRangePickerProps,
   DateTimePickerProps,
+  DateTimePickerRef,
   DropdownWithItemsProps,
   MultiSelectProps,
   SelectFieldItemsProps,
@@ -29,6 +30,10 @@ const wrongRef = (element: HTMLDivElement | null) => {
 }
 const wrongObjectRef = { current: null as HTMLDivElement | null }
 const wrongSvgObjectRef = { current: null as SVGSVGElement | null }
+const wrongTableObjectRef = { current: null as HTMLTableElement | null }
+const wrongDateTimePseudoRef = {
+  current: { value: new Date() } as { value?: Date } | null,
+}
 
 function acceptsCheckboxProps(props: CheckboxProps) {
   return props
@@ -228,12 +233,16 @@ function acceptsDateTimePickerProps(props: DateTimePickerProps) {
   return props
 }
 
+const dateTimeButtonRef = (value: DateTimePickerRef | null) => {
+  void value
+}
+
 acceptsDateTimePickerProps({
   locale: undefined,
   weekStartsOn: undefined,
   showWeekNumber: false,
   showOutsideDays: false,
-  ref: buttonRef,
+  ref: dateTimeButtonRef,
 })
 acceptsDateTimePickerProps({
   locale: undefined,
@@ -242,6 +251,14 @@ acceptsDateTimePickerProps({
   showOutsideDays: false,
   // @ts-expect-error DateTimePicker refs must target the calendar trigger button.
   ref: wrongObjectRef,
+})
+acceptsDateTimePickerProps({
+  locale: undefined,
+  weekStartsOn: undefined,
+  showWeekNumber: false,
+  showOutsideDays: false,
+  // @ts-expect-error The removed pseudo-ref with a Date-valued `.value` must not compile.
+  ref: wrongDateTimePseudoRef,
 })
 
 type Row = { name: string; className?: string }
@@ -263,7 +280,7 @@ acceptsTableProps({
   columns: [{ accessor: 'name', label: 'Name' }],
   data: [{ name: 'Ada' }],
   // @ts-expect-error Table refs expose the imperative TableRef, not the DOM table element.
-  ref: wrongObjectRef,
+  ref: wrongTableObjectRef,
 })
 acceptsTableProps({
   columns: [{ accessor: 'name', label: 'Name' }],

--- a/packages/design-system/tests/contracts/composite-refs.types.ts
+++ b/packages/design-system/tests/contracts/composite-refs.types.ts
@@ -1,0 +1,273 @@
+import type {
+  AlphaNumericPinFieldProps,
+  CheckboxProps,
+  CollapsibleProps,
+  ColorPickerProps,
+  DatePickerProps,
+  DateRangePickerProps,
+  DateTimePickerProps,
+  DropdownWithItemsProps,
+  MultiSelectProps,
+  SelectFieldItemsProps,
+  SliderWithLabelProps,
+  SwitchProps,
+  TableProps,
+  TableRef,
+} from '../../src'
+
+const buttonRef = (element: HTMLButtonElement | null) => {
+  void element
+}
+const inputRef = (element: HTMLInputElement | null) => {
+  void element
+}
+const spanRef = (element: HTMLSpanElement | null) => {
+  void element
+}
+const wrongRef = (element: HTMLDivElement | null) => {
+  void element
+}
+const wrongObjectRef = { current: null as HTMLDivElement | null }
+const wrongSvgObjectRef = { current: null as SVGSVGElement | null }
+
+function acceptsCheckboxProps(props: CheckboxProps) {
+  return props
+}
+
+acceptsCheckboxProps({
+  checked: false,
+  onCheck: () => undefined,
+  ref: buttonRef,
+})
+acceptsCheckboxProps({
+  checked: false,
+  onCheck: () => undefined,
+  // @ts-expect-error Checkbox refs must target the Radix button root.
+  ref: wrongSvgObjectRef,
+})
+
+function acceptsSwitchProps(props: SwitchProps) {
+  return props
+}
+
+acceptsSwitchProps({
+  checked: false,
+  onCheckedChange: () => undefined,
+  ref: buttonRef,
+})
+acceptsSwitchProps({
+  checked: false,
+  onCheckedChange: () => undefined,
+  // @ts-expect-error Switch refs must target the Radix button root.
+  ref: wrongRef,
+})
+
+function acceptsSliderProps(props: SliderWithLabelProps) {
+  return props
+}
+
+acceptsSliderProps({
+  min: 0,
+  max: 10,
+  step: 1,
+  handleChange: () => undefined,
+  ref: spanRef,
+})
+acceptsSliderProps({
+  min: 0,
+  max: 10,
+  step: 1,
+  handleChange: () => undefined,
+  // @ts-expect-error Slider refs must target the focusable thumb span.
+  ref: wrongSvgObjectRef,
+})
+
+function acceptsCollapsibleProps(props: CollapsibleProps) {
+  return props
+}
+
+acceptsCollapsibleProps({
+  open: false,
+  onChange: () => undefined,
+  staticContent: 'Static',
+  children: 'Content',
+  ref: buttonRef,
+})
+acceptsCollapsibleProps({
+  open: false,
+  onChange: () => undefined,
+  staticContent: 'Static',
+  children: 'Content',
+  // @ts-expect-error Collapsible refs must target the trigger button.
+  ref: wrongObjectRef,
+})
+
+function acceptsDropdownProps(props: DropdownWithItemsProps) {
+  return props
+}
+
+acceptsDropdownProps({
+  trigger: 'Open',
+  ref: buttonRef,
+  items: [{ id: 'one', label: 'One', onClick: () => undefined }],
+})
+acceptsDropdownProps({
+  trigger: 'Open',
+  items: [{ id: 'one', label: 'One', onClick: () => undefined }],
+  // @ts-expect-error Dropdown refs must target the menu trigger button.
+  ref: wrongRef,
+})
+
+function acceptsMultiSelectProps(props: MultiSelectProps) {
+  return props
+}
+
+acceptsMultiSelectProps({
+  items: [{ value: 'one', label: 'One' }],
+  value: [],
+  onChange: () => undefined,
+  ref: buttonRef,
+})
+acceptsMultiSelectProps({
+  items: [{ value: 'one', label: 'One' }],
+  value: [],
+  onChange: () => undefined,
+  // @ts-expect-error MultiSelect refs must target the visible trigger button.
+  ref: wrongObjectRef,
+})
+
+function acceptsSelectFieldProps(props: SelectFieldItemsProps) {
+  return props
+}
+
+acceptsSelectFieldProps({
+  items: [{ value: 'one', label: 'One' }],
+  onChange: () => undefined,
+  ref: buttonRef,
+})
+acceptsSelectFieldProps({
+  items: [{ value: 'one', label: 'One' }],
+  onChange: () => undefined,
+  // @ts-expect-error SelectField refs must target the delegated trigger button.
+  ref: wrongRef,
+})
+
+function acceptsAlphaNumericPinFieldProps(props: AlphaNumericPinFieldProps) {
+  return props
+}
+
+acceptsAlphaNumericPinFieldProps({
+  value: '',
+  onChange: async () => undefined,
+  length: 6,
+  ref: inputRef,
+})
+acceptsAlphaNumericPinFieldProps({
+  value: '',
+  onChange: async () => undefined,
+  length: 6,
+  // @ts-expect-error AlphaNumericPinField refs must target the OTP input.
+  ref: wrongObjectRef,
+})
+
+function acceptsColorPickerProps(props: ColorPickerProps) {
+  return props
+}
+
+acceptsColorPickerProps({
+  color: '#000000',
+  onSubmit: () => undefined,
+  submitText: 'Save',
+  colorLabel: 'Color',
+  triggerAriaLabel: 'Pick a color',
+  ref: buttonRef,
+})
+acceptsColorPickerProps({
+  color: '#000000',
+  onSubmit: () => undefined,
+  submitText: 'Save',
+  colorLabel: 'Color',
+  triggerAriaLabel: 'Pick a color',
+  // @ts-expect-error ColorPicker refs must target the palette trigger button.
+  ref: wrongRef,
+})
+
+function acceptsDatePickerProps(props: DatePickerProps) {
+  return props
+}
+
+acceptsDatePickerProps({
+  date: undefined,
+  onDateChange: () => undefined,
+  ref: buttonRef,
+})
+acceptsDatePickerProps({
+  date: undefined,
+  onDateChange: () => undefined,
+  // @ts-expect-error DatePicker refs must target the calendar trigger button.
+  ref: wrongObjectRef,
+})
+
+function acceptsDateRangePickerProps(props: DateRangePickerProps) {
+  return props
+}
+
+acceptsDateRangePickerProps({
+  range: undefined,
+  onRangeChange: () => undefined,
+  ref: buttonRef,
+})
+acceptsDateRangePickerProps({
+  range: undefined,
+  onRangeChange: () => undefined,
+  // @ts-expect-error DateRangePicker refs must target the calendar trigger button.
+  ref: wrongRef,
+})
+
+function acceptsDateTimePickerProps(props: DateTimePickerProps) {
+  return props
+}
+
+acceptsDateTimePickerProps({
+  locale: undefined,
+  weekStartsOn: undefined,
+  showWeekNumber: false,
+  showOutsideDays: false,
+  ref: buttonRef,
+})
+acceptsDateTimePickerProps({
+  locale: undefined,
+  weekStartsOn: undefined,
+  showWeekNumber: false,
+  showOutsideDays: false,
+  // @ts-expect-error DateTimePicker refs must target the calendar trigger button.
+  ref: wrongObjectRef,
+})
+
+type Row = { name: string; className?: string }
+
+function acceptsTableProps(props: TableProps<Row>) {
+  return props
+}
+
+const tableRef = (value: TableRef | null) => {
+  void value
+}
+
+acceptsTableProps({
+  columns: [{ accessor: 'name', label: 'Name' }],
+  data: [{ name: 'Ada' }],
+  ref: tableRef,
+})
+acceptsTableProps({
+  columns: [{ accessor: 'name', label: 'Name' }],
+  data: [{ name: 'Ada' }],
+  // @ts-expect-error Table refs expose the imperative TableRef, not the DOM table element.
+  ref: wrongObjectRef,
+})
+acceptsTableProps({
+  columns: [{ accessor: 'name', label: 'Name' }],
+  data: [{ name: 'Ada' }],
+  // @ts-expect-error Table's removed forwardedRef alias must not compile.
+  forwardedRef: tableRef,
+})

--- a/packages/design-system/tsconfig.types.json
+++ b/packages/design-system/tsconfig.types.json
@@ -7,6 +7,7 @@
   },
   "include": [
     "tests/contracts/public-contracts.types.ts",
-    "tests/contracts/direct-control-refs.types.ts"
+    "tests/contracts/direct-control-refs.types.ts",
+    "tests/contracts/composite-refs.types.ts"
   ]
 }

--- a/project/2026-08-02-v5-composite-refs-plan.md
+++ b/project/2026-08-02-v5-composite-refs-plan.md
@@ -194,9 +194,9 @@ regenerate after the source contract is stable.
 - For `DateTimePicker`, replace the public `React.forwardRef` pseudo-handle
   and `useImperativeHandle` with a normal React 19 ref-as-prop function,
   retain the internal button ref only if needed for local behavior, and expose
-  the actual trigger `HTMLButtonElement`. Redefine the exported
-  `DateTimePickerRef` compatibility name as `HTMLButtonElement` only if that
-  keeps existing type imports useful; document that `.value` is removed.
+  the actual trigger `HTMLButtonElement`. Keep the exported
+  `DateTimePickerRef` name as an `HTMLButtonElement` alias so existing type
+  imports remain useful, and document that `.value` is removed.
 - Preserve all existing event handlers, controlled state, labels, data
   attributes, Radix composition, and theme classes.
 
@@ -362,3 +362,7 @@ container.
   multi-target surfaces remain excluded.
 - 2026-08-02: Plan authored as the first A3 branch change. Implementation,
   review, final gates, and draft PR publication remain pending.
+- 2026-08-02: The configured plan-review agent did not return after two
+  bounded waits and was interrupted without edits. Sol's live-source review
+  remains the independent scope review; the primary session performed a
+  read-only fallback audit of the exact plan commit before W1.

--- a/project/2026-08-02-v5-composite-refs-plan.md
+++ b/project/2026-08-02-v5-composite-refs-plan.md
@@ -405,3 +405,12 @@ container.
   `pnpm@10.30.0` could not fetch or verify its npm registry signatures. No
   signature override or dependency mutation was used; the equivalent installed
   `tsc` binaries passed directly.
+- 2026-08-02: The first forge run reached the repository checks but failed only
+  at package-wide Prettier validation. The formatter log named seven touched
+  source files (`Checkbox.tsx`, `Collapsible.tsx`, `ColorPicker.tsx`,
+  `Dropdown.tsx`, `MultiSelect.tsx`, `Slider.tsx`, and `Table.tsx`). Installed
+  repository Prettier was run on those files, producing only class-order
+  changes in `ef0e29bb`; no ref, runtime, type, story, or migration semantics
+  changed. The PR body and final verification state must be refreshed after
+  this corrective push, with forge checks still treated as pending until the
+  rerun is read back.

--- a/project/2026-08-02-v5-composite-refs-plan.md
+++ b/project/2026-08-02-v5-composite-refs-plan.md
@@ -420,3 +420,9 @@ container.
   files, and `6f77e8ff` only appends plan progress. The local Prettier check
   for all seven forge-named files is green; no new semantic review surface was
   introduced.
+- 2026-08-02: Forge CI run `30745547873` is fully green: formatting, types,
+  lint, smoke Test (`460 passed`), all four A11y shards (`193 passed` each),
+  Greptile review, and the build-only `Build and Publish` job. Its npm publish
+  and dist-tag steps were skipped, as required. The draft PR remains open and
+  targets `v5`; no merge, ready-for-review transition, tag, release, or main
+  branch operation was performed.

--- a/project/2026-08-02-v5-composite-refs-plan.md
+++ b/project/2026-08-02-v5-composite-refs-plan.md
@@ -74,8 +74,10 @@ The ref is an imperative `TableRef`, not an `HTMLTableElement`; the contract
 must not claim DOM methods that Table does not expose.
 
 For DOM composites, the public `ref` is a concrete `React.Ref<T>` passed to
-the one visible, focusable target. No new `forwardedRef`, `unknown`, wrapper
-ref, polymorphic-ref abstraction, or compatibility alias is allowed.
+the one visible, focusable target. No new `forwardedRef` prop alias, `unknown`
+target, wrapper ref, or polymorphic-ref abstraction is allowed. The existing
+`DateTimePickerRef` type export is intentionally retained as a direct
+`HTMLButtonElement` alias so type-only imports do not break unnecessarily.
 
 ## Sol's independent inventory and decision
 
@@ -146,14 +148,14 @@ const tableRef = useRef<TableRef>(null)
 
 ## Decision gates and stop conditions
 
-| Gate                              | Decision/evidence required                                                                                                                | Stop if                                                                                                                          |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| D1 — base                         | `origin/v5` and the placeholder branch still equal `b7d72b5f`; worktree is clean before implementation                                    | v5 moves or unrelated work appears in the A3 worktree; checkpoint and ask before rebasing or widening                            |
-| D2 — target                       | Each included component has exactly one visible interactive target matching the inventory                                                 | A candidate is polymorphic, conditional, multi-target, or lands the ref on a wrapper                                             |
-| D3 — DateTimePicker compatibility | No verified consumer requires the old pseudo-ref `.value` property; selected date remains available through controlled `value`/`onChange` | A real consumer depends on `.value`; stop and ask for a compatibility decision rather than silently preserving an unsound object |
-| D4 — behavior                     | Focus, keyboard, open/close, selection, Table sorting, reset, and a11y behavior remain green                                              | Any regression in these behaviors or in accessible names/roles                                                                   |
-| D5 — declarations                 | Built declarations expose the concrete targets and `TableRef`; no `forwardedRef` remains                                                  | Generated declarations are widened, stale, or retain the alias                                                                   |
-| D6 — publication                  | All review, security, maintainability, CI, and description gates pass before a draft PR is submitted                                      | A gate is missing, blocked, or only assumed from a plan file                                                                     |
+| Gate                              | Decision/evidence required                                                                                                                                                              | Stop if                                                                                                                          |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| D1 — base                         | `origin/v5` remains `b7d72b5f`; the branch is cleanly descended from that base (`git merge-base --is-ancestor b7d72b5f HEAD`) and the dedicated worktree is clean before implementation | v5 moves, ancestry is lost, or unrelated work appears in the A3 worktree; checkpoint and ask before rebasing or widening         |
+| D2 — target                       | Each included component has exactly one visible interactive target matching the inventory                                                                                               | A candidate is polymorphic, conditional, multi-target, or lands the ref on a wrapper                                             |
+| D3 — DateTimePicker compatibility | No verified consumer requires the old pseudo-ref `.value` property; selected date remains available through controlled `value`/`onChange`                                               | A real consumer depends on `.value`; stop and ask for a compatibility decision rather than silently preserving an unsound object |
+| D4 — behavior                     | Focus, keyboard, open/close, selection, Table sorting, reset, and a11y behavior remain green                                                                                            | Any regression in these behaviors or in accessible names/roles                                                                   |
+| D5 — declarations                 | Built declarations expose the concrete targets and `TableRef`; no `forwardedRef` remains                                                                                                | Generated declarations are widened, stale, or retain the alias                                                                   |
+| D6 — publication                  | Local implementation/review/security/maintainability gates pass before draft submission; forge CI then passes before ready-for-review                                                   | A gate is missing, blocked, or only assumed from a plan file                                                                     |
 
 ## Work sequence and commit boundaries
 
@@ -285,8 +287,9 @@ regenerate after the source contract is stable.
   `DateTimePickerRef`, `TableRef`, and absence of `forwardedRef`.
 - Append verified results, exact commands, and any pre-existing tool warnings
   to this plan's `Progress` section. Do not rewrite prior entries.
-- Commit only generated output and progress when source behavior is already
-  reviewed.
+- Commit only a tracked progress update when source behavior is already
+  reviewed. Generated `dist` output is ignored and is inspection evidence, not
+  a force-added artifact.
 
 **Check**
 
@@ -295,7 +298,8 @@ regenerate after the source contract is stable.
 
 **Commit**
 
-`chore(refs): refresh v5 composite declarations`
+`docs(project): record A3 final verification` (only if the progress update is
+the only remaining tracked change)
 
 ## Verification matrix
 
@@ -317,7 +321,7 @@ container.
 | Security                 | bounded `$security-review` over the exact implementation range                                                | no unverified high-confidence issue; pre-existing findings separated    |
 | Maintainability          | mandatory `$thermo-nuclear-code-quality-review` over the exact final range                                    | pass or verified findings resolved                                      |
 | Independent final review | opposing provider or `agy` where available; current-provider fallback recorded if unavailable                 | no unresolved blocking finding                                          |
-| Forge/CI                 | required checks on the draft PR                                                                               | green before ready-for-review; do not merge in this goal                |
+| Forge/CI                 | submit the draft PR after local gates, then read its required checks                                          | green before ready-for-review; do not merge in this goal                |
 
 ## Review and publication routing
 
@@ -366,3 +370,9 @@ container.
   bounded waits and was interrupted without edits. Sol's live-source review
   remains the independent scope review; the primary session performed a
   read-only fallback audit of the exact plan commit before W1.
+- 2026-08-02: The fallback plan review found four issues and they were
+  accepted: D1 now checks ancestry rather than impossible branch equality;
+  `DateTimePickerRef` is explicitly retained as an `HTMLButtonElement` type
+  alias while no `forwardedRef` prop alias is retained; draft publication is
+  separated from post-push CI readiness; and ignored generated declarations
+  are inspected rather than force-added.

--- a/project/2026-08-02-v5-composite-refs-plan.md
+++ b/project/2026-08-02-v5-composite-refs-plan.md
@@ -400,3 +400,8 @@ container.
   public API. Remaining matches are the migration explanation, the negative
   type test, and an existing local variable in the excluded Modal story's
   `forwardRef` example; none is a shipped A3 prop alias.
+- 2026-08-02: The repository `pnpm --dir packages/design-system check`
+  wrapper was also attempted and stopped before running checks because
+  `pnpm@10.30.0` could not fetch or verify its npm registry signatures. No
+  signature override or dependency mutation was used; the equivalent installed
+  `tsc` binaries passed directly.

--- a/project/2026-08-02-v5-composite-refs-plan.md
+++ b/project/2026-08-02-v5-composite-refs-plan.md
@@ -376,3 +376,27 @@ container.
   alias while no `forwardedRef` prop alias is retained; draft publication is
   separated from post-push CI readiness; and ignored generated declarations
   are inspected rather than force-added.
+- 2026-08-02: W1 implemented the twelve concrete DOM ref targets and the
+  DateTimePicker handle correction in `306dfab8`; W3 added the Table
+  imperative `TableRef`, the contract story/type fixture, migration guidance,
+  and the first focused runtime proof in `f15386bc`. The review identified
+  missing stateful-selection assertions; `45e11f5b` added Collapsible and
+  ColorPicker toggle coverage plus deterministic menu, select, date, and
+  color selections with focus-return checks. That follow-up also adds the
+  optional Slider accessible name used by the contract story.
+- 2026-08-02: The focused composite contract is green (`4 passed`), the
+  existing keyboard and direct-control contracts are green (`16 passed`),
+  and the full Ladle accessibility suite is green (`772 passed` across
+  neutral and UZH). The composite story emits only the existing moderate
+  `region` inventory entry; no new blocking axe finding remains.
+- 2026-08-02: Package source and durable type checks passed; `tsc -b`, Vite
+  declaration build, and the asset-copy step passed (the unprivileged `tsx`
+  invocation initially hit an IPC `EPERM` and was rerun with host permissions).
+  Generated declarations contain concrete DOM ref types, `DateTimePickerRef`
+  as `HTMLButtonElement`, and `TableRef`; generated `dist` remains ignored.
+  Changed-file ESLint passed. Prettier reports pre-existing ordering drift in
+  `Slider.tsx` and `Table.tsx`; no whole-file reformat was introduced.
+- 2026-08-02: The deliberate `forwardedRef` search is clean for the removed
+  public API. Remaining matches are the migration explanation, the negative
+  type test, and an existing local variable in the excluded Modal story's
+  `forwardRef` example; none is a shipped A3 prop alias.

--- a/project/2026-08-02-v5-composite-refs-plan.md
+++ b/project/2026-08-02-v5-composite-refs-plan.md
@@ -414,3 +414,9 @@ container.
   changed. The PR body and final verification state must be refreshed after
   this corrective push, with forge checks still treated as pending until the
   rerun is read back.
+- 2026-08-02: The final bounded security and thermo-nuclear maintainability
+  confirmations covered `b7d72b5f..6f77e8ff`. Both remain PASS with no findings:
+  `ef0e29bb` only reorders equivalent utility tokens in seven reviewed source
+  files, and `6f77e8ff` only appends plan progress. The local Prettier check
+  for all seven forge-named files is green; no new semantic review surface was
+  introduced.

--- a/project/2026-08-02-v5-composite-refs-plan.md
+++ b/project/2026-08-02-v5-composite-refs-plan.md
@@ -1,0 +1,364 @@
+# Plan — v5 composite refs and Table migration (Stack A3)
+
+## Identity and status
+
+- Date: 2026-08-02
+- Status: approved execution plan; implementation not started
+- Repository: `/Users/rschlae/Git/df/design-system`
+- Worktree: `trees/rs-v5-composite-refs`
+- Branch: `rs/v5-composite-refs`
+- Target/trunk: `v5`
+- Base: `b7d72b5f309594ebfb02261c1fb35e85345a88bd` (merged A2, PR #187)
+- Parent layers: A1 PR #186 and A2 PR #187, both merged into `v5`
+- PR: none yet; the branch is an empty v5-aligned placeholder
+- Release policy: this work may be reviewed and submitted as a draft PR into
+  `v5`; it must not target or merge into `main`, tag, publish, or merge
+  without a separate explicit authority decision
+- Plan owner: primary Codex session; Sol provided the independent inventory
+  and implementation recommendation recorded below
+
+This is the execution plan for Stack A3 in the release-readiness roadmap. A1
+and A2 are already merged, so A3 is now one standalone review layer rooted at
+the current `v5` trunk. It is not a dependent PR targeting either predecessor,
+and it is not a reason to create a new native stack topology.
+
+## Goal
+
+Give every applicable v5 composite one honest React 19 `ref` contract aimed at
+its meaningful interactive target, and replace Table's bespoke
+`forwardedRef` prop with a typed imperative `ref`. Keep behavior, keyboard
+interaction, accessibility, styling, exports, and package boundaries stable
+except for the intentional breaking ref-contract changes documented for v5.
+
+## Current verified state
+
+| Surface              | Evidence and consequence                                                                                                                                                                                                                                                                             |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v5`                 | Local `v5`, `origin/v5`, `rs/v5-composite-refs`, and `origin/rs/v5-composite-refs` all point to `b7d72b5f`; no A3 PR exists.                                                                                                                                                                         |
+| `main`               | `origin/main` is a separate release line and is explicitly out of scope. No command in this plan may target it.                                                                                                                                                                                      |
+| A1/A2                | PR #186 (`66a3f649`) and PR #187 (`b7d72b5f`) are merged into `v5`; their plans define the React 19 ref-as-prop convention and the `Button asChild` safety boundary.                                                                                                                                 |
+| Native stack support | GitHub's native stacks endpoint is available, but A3 has no child layer. Use the existing branch and ordinary/native draft submission mechanics only after the final gates. Never invent a replacement stack, rebase through the trunk, queue, reorder, unstack, delete, or merge without authority. |
+| Worktree hygiene     | `trees/` is ignored and the dedicated worktree is clean. The root checkout has unrelated untracked `.pnpm-store/` and roadmap artifacts and must not be used for implementation.                                                                                                                     |
+| Package manager      | The repository's `pnpm` wrapper stops at its pinned registry-signature check. Use the installed package binaries for local checks; do not change dependencies or bypass the signature policy.                                                                                                        |
+| Browser proof        | Ladle production build and direct Playwright binaries are available. Real story interaction is the validation path for ref placement, focus, keyboard, open/close, and Table reset behavior.                                                                                                         |
+
+## Problem and design contract
+
+The A2 direct-control layer established normal React 19 refs for Button,
+fields, and Select/Combobox triggers. A3 must extend the same convention to
+composites without exposing wrappers, decorative roots, arbitrary child types,
+or stale aliases. The current Table is the only public bespoke alias found by
+the source inventory:
+
+- `packages/design-system/src/Table.tsx` accepts `forwardedRef?:
+React.Ref<unknown>` and passes it to `useImperativeHandle`.
+- `Table.stories.mdx` documents both `ref` and `forwardedRef`, while the
+  `ResetTable` story still calls `forwardedRef={ref}`.
+- The migration guide explicitly defers Table and composite refs after A2.
+
+Table's new public type is:
+
+```ts
+export interface TableRef {
+  reset(): void;
+}
+
+export interface TableProps<RowType extends BaseRowType> {
+  ref?: React.Ref<TableRef>;
+  // existing props remain unchanged
+}
+```
+
+`useImperativeHandle(ref, ...)` must preserve the existing reset semantics.
+The ref is an imperative `TableRef`, not an `HTMLTableElement`; the contract
+must not claim DOM methods that Table does not expose.
+
+For DOM composites, the public `ref` is a concrete `React.Ref<T>` passed to
+the one visible, focusable target. No new `forwardedRef`, `unknown`, wrapper
+ref, polymorphic-ref abstraction, or compatibility alias is allowed.
+
+## Sol's independent inventory and decision
+
+Sol reviewed the live v5 source and returned `DONE_WITH_CONCERNS`. The concern
+was that a Table-only patch would leave the roadmap's deferred composite-ref
+work incomplete, while `DateTimePicker` currently promises a hybrid button/date
+object that is not the runtime object returned after object spreading a DOM
+button. The recommendation is accepted for this plan: include every listed
+composite with one stable meaningful target, and stop rather than preserve an
+unverified legacy DateTimePicker pseudo-value handle.
+
+### Included DOM composites
+
+| Component              | Source                               | Ref target and reason                                                     |
+| ---------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
+| `Checkbox`             | `src/Checkbox.tsx`                   | `HTMLButtonElement`, Radix checkbox root                                  |
+| `Switch`               | `src/Switch.tsx`                     | `HTMLButtonElement`, Radix switch root                                    |
+| `Slider`               | `src/Slider.tsx`                     | `HTMLSpanElement`, the single focusable Radix thumb                       |
+| `Collapsible`          | `src/Collapsible.tsx`                | `HTMLButtonElement`, the Radix trigger                                    |
+| `Dropdown`             | `src/Dropdown.tsx`                   | `HTMLButtonElement`, the visible menu trigger                             |
+| `MultiSelect`          | `src/MultiSelect.tsx`                | `HTMLButtonElement`, the visible popover trigger                          |
+| `SelectField`          | `src/forms/SelectField.tsx`          | `HTMLButtonElement`, delegated through `Select`                           |
+| `AlphaNumericPinField` | `src/forms/AlphaNumericPinField.tsx` | `HTMLInputElement`, the underlying `input-otp` input                      |
+| `ColorPicker`          | `src/ColorPicker.tsx`                | `HTMLButtonElement`, the palette trigger                                  |
+| `DatePicker`           | `src/DatePicker.tsx`                 | `HTMLButtonElement`, the calendar trigger                                 |
+| `DateRangePicker`      | `src/DateRangePicker.tsx`            | `HTMLButtonElement`, the calendar trigger                                 |
+| `DateTimePicker`       | `src/DatetimePicker.tsx`             | `HTMLButtonElement`, the calendar trigger; remove the pseudo-value object |
+
+The exact prop names, state model, labels, and child content remain unchanged.
+Only the ref seam and the documentation/tests needed to prove it are in scope.
+For Radix and `input-otp` components, verify the installed declarations before
+choosing the target type; if the rendered target differs from this table, stop
+and record the mismatch instead of widening the contract.
+
+### Included Table contract
+
+`TableRef` is exported from `src/Table.tsx` through the existing root export.
+Remove `forwardedRef` from the public props and from all README, AI-documentation,
+story, migration, and test prose. A consumer using `forwardedRef` must fail the
+durable type fixture; the supported before/after migration is:
+
+```tsx
+// v4 / pre-A3
+<Table forwardedRef={tableRef} ... />
+
+// v5
+const tableRef = useRef<TableRef>(null)
+<Table ref={tableRef} ... />
+```
+
+### Explicit exclusions
+
+- Deprecated `Formik*` wrappers: frozen for v5 and removed in v6; do not
+  modernize their ref APIs as part of A3.
+- `Modal` and `Tooltip`: `asChild` triggers can be arbitrary elements, so a
+  single concrete target would be unsound.
+- `Navigation`, `Tabs`, `Workflow`, and `StepProgress`: they expose multiple
+  independently focusable controls and have no honest singular target.
+- `Tag` and `UserNotification`: focus is conditional or secondary rather than
+  a stable public control contract.
+- Headers, progress/countdown/theme/layout wrappers, and other passive
+  composites: ceremonial refs add API without useful imperative leverage.
+- Raw primitives under the existing `./primitives` export: their own
+  React/Radix contracts already own refs.
+- Selector normalization, visual redesign, a11y CI policy changes, Formik
+  modernization, polymorphic-ref abstraction, package-export changes, bundle
+  work, new dependencies, release/tag/publish, and any `main` operation.
+
+## Decision gates and stop conditions
+
+| Gate                              | Decision/evidence required                                                                                                                | Stop if                                                                                                                          |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| D1 — base                         | `origin/v5` and the placeholder branch still equal `b7d72b5f`; worktree is clean before implementation                                    | v5 moves or unrelated work appears in the A3 worktree; checkpoint and ask before rebasing or widening                            |
+| D2 — target                       | Each included component has exactly one visible interactive target matching the inventory                                                 | A candidate is polymorphic, conditional, multi-target, or lands the ref on a wrapper                                             |
+| D3 — DateTimePicker compatibility | No verified consumer requires the old pseudo-ref `.value` property; selected date remains available through controlled `value`/`onChange` | A real consumer depends on `.value`; stop and ask for a compatibility decision rather than silently preserving an unsound object |
+| D4 — behavior                     | Focus, keyboard, open/close, selection, Table sorting, reset, and a11y behavior remain green                                              | Any regression in these behaviors or in accessible names/roles                                                                   |
+| D5 — declarations                 | Built declarations expose the concrete targets and `TableRef`; no `forwardedRef` remains                                                  | Generated declarations are widened, stale, or retain the alias                                                                   |
+| D6 — publication                  | All review, security, maintainability, CI, and description gates pass before a draft PR is submitted                                      | A gate is missing, blocked, or only assumed from a plan file                                                                     |
+
+## Work sequence and commit boundaries
+
+The plan itself travels with the implementation. Each implementation slice is
+small enough to review and verify independently, and each slice gets a
+current-provider review plus a separate simplification pass before the next
+slice. Do not combine generated declaration churn into earlier source commits;
+regenerate after the source contract is stable.
+
+### W0 — plan and inventory (first commit)
+
+**Do**
+
+- Add this file as the only staged change on the existing A3 branch.
+- Record the live base, worktree, target, topology, Sol result, included and
+  excluded inventory, tests, gates, and authority boundaries.
+
+**Check**
+
+- Inspect `git diff --cached` for secrets, credentials, private URLs, PII, and
+  unrelated root-worktree files.
+- Run Prettier on the plan and confirm the worktree contains only the plan.
+
+**Commit**
+
+`docs(project): add v5 composite refs plan`
+
+### W1 — concrete DOM ref contracts
+
+**Do**
+
+- Add explicit `ref?: React.Ref<T>` props to the twelve included DOM
+  composites and destructure/thread them to the exact target in the inventory.
+- For `SelectField`, pass the ref through the existing `Select` prop; do not
+  expose the `Select` wrapper div.
+- For `AlphaNumericPinField`, pass the ref through `InputOTP` to the actual
+  input and verify the installed `input-otp` type supports it.
+- For `DateTimePicker`, replace the public `React.forwardRef` pseudo-handle
+  and `useImperativeHandle` with a normal React 19 ref-as-prop function,
+  retain the internal button ref only if needed for local behavior, and expose
+  the actual trigger `HTMLButtonElement`. Redefine the exported
+  `DateTimePickerRef` compatibility name as `HTMLButtonElement` only if that
+  keeps existing type imports useful; document that `.value` is removed.
+- Preserve all existing event handlers, controlled state, labels, data
+  attributes, Radix composition, and theme classes.
+
+**Check**
+
+- Add `tests/contracts/composite-refs.types.ts` and include it in
+  `tsconfig.types.json`. Positive cases use the exact target for every
+  component; negative `@ts-expect-error` cases cover a wrong DOM target,
+  missing/unsupported aliases, and Table's separate imperative type.
+- Use no new abstraction until repeated implementation is proven; direct
+  prop threading is preferred.
+- Run direct TypeScript, focused ESLint, and Prettier before review.
+
+**Commit**
+
+`feat(refs): expose v5 composite DOM refs`
+
+### W2 — Table imperative ref migration
+
+**Do**
+
+- Add and export `TableRef { reset(): void }`.
+- Change `TableProps` from `forwardedRef?: React.Ref<unknown>` to
+  `ref?: React.Ref<TableRef>` and pass it to `useImperativeHandle`.
+- Keep generic row constraints, sorting state, default sort behavior, and
+  reset behavior unchanged.
+- Remove every `forwardedRef` source reference from Table implementation and
+  public type surfaces.
+
+**Check**
+
+- Extend the durable type fixture with a valid `TableRef` callback/object ref,
+  a wrong `HTMLTableElement` ref, and `@ts-expect-error` for `forwardedRef`.
+- Add a focused runtime contract for `ref.current.reset()` and a reset from a
+  non-default sort state; keep the existing Table keyboard/a11y contract
+  (aria-sort none → ascending → descending → ascending) intact.
+- Run package type checks and the focused Table contract before review.
+
+**Commit**
+
+`enhance(refs): migrate Table to the typed ref contract`
+
+### W3 — stories, migration, and focused runtime proof
+
+**Do**
+
+- Update `Table.stories.mdx`: remove `forwardedRef` from README and AI docs,
+  use `useRef<TableRef>(null)`, call `ref.current?.reset()`, and add a stable
+  selector for the reset proof if the existing story lacks one.
+- Add or extend a focused composite-ref Ladle story with one deterministic
+  focus action per included target. Keep the story accessible in neutral and
+  UZH themes; do not create visual redesign work.
+- Add `tests/contracts/composite-refs.spec.ts` using the existing Ladle
+  helpers. Assert actual `document.activeElement` identity for each target;
+  for stateful triggers exercise Enter/open, Escape/close, selection where
+  applicable, and focus return. For Slider assert the thumb; for OTP assert
+  the underlying input; for Table assert sorting and reset.
+- Update `packages/design-system/MIGRATION.md` with the complete component →
+  target table, the `forwardedRef` → `ref` Table example, `TableRef`, and the
+  DateTimePicker change from the pseudo-value handle to the real button. Tell
+  consumers to read the selected date from controlled state.
+- Search all package stories/docs/source for `forwardedRef`; only historical
+  migration wording describing the removed API may remain, and it must be
+  intentional.
+
+**Check**
+
+- Direct changed-file ESLint, Prettier, package type checks, and the focused
+  Playwright contract.
+- Run the full `tests/a11y` suite separately from the focused proof; preserve
+  existing Table keyboard coverage and all A1/A2 behavior.
+- Capture neutral/UZH Ladle screenshots for the changed story states if the
+  PR evidence path accepts them; if no visual output changed, record that
+  rationale in the PR rather than inventing visual snapshots.
+
+**Commit**
+
+`test(refs): prove composite focus and Table reset contracts`
+
+### W4 — generated artifacts, final verification, and progress
+
+**Do**
+
+- Run the package build to regenerate declarations and copied assets; inspect
+  the generated `dist` declarations for each concrete ref target,
+  `DateTimePickerRef`, `TableRef`, and absence of `forwardedRef`.
+- Append verified results, exact commands, and any pre-existing tool warnings
+  to this plan's `Progress` section. Do not rewrite prior entries.
+- Commit only generated output and progress when source behavior is already
+  reviewed.
+
+**Check**
+
+- Run all mandatory gates below and record pass/fail separately; a green
+  report is evidence only when the producing build/test actually ran.
+
+**Commit**
+
+`chore(refs): refresh v5 composite declarations`
+
+## Verification matrix
+
+Use repository-native tools and the installed binaries where the pnpm wrapper
+is blocked. Run from the A3 worktree; do not run Git or forge commands inside a
+container.
+
+| Gate                     | Command/evidence                                                                                              | Required result                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Source type check        | `./node_modules/.bin/tsc --noEmit` from `packages/design-system`                                              | pass                                                                    |
+| Durable contract types   | `./node_modules/.bin/tsc -p tsconfig.types.json --noEmit`                                                     | pass with all intended `@ts-expect-error` cases consumed                |
+| Changed-file lint        | `./node_modules/.bin/eslint <changed TS/TSX files> --report-unused-disable-directives --max-warnings 0`       | pass                                                                    |
+| Formatting               | `./node_modules/.bin/prettier --check <changed files>`                                                        | pass; pre-existing legacy MDX drift recorded, not reformatted wholesale |
+| Library build            | package `tsc -b`, Vite build, copy step through direct binaries or `pnpm` if the signature check is available | pass; declarations inspected                                            |
+| Ladle                    | `./node_modules/.bin/ladle build` with `LADLE=true`                                                           | pass; changed stories present in metadata                               |
+| Focused runtime          | `PWTEST_SKIP_BUILD=1 ./node_modules/.bin/playwright test tests/contracts/composite-refs.spec.ts`              | all target focus/open-close/reset cases pass                            |
+| Existing Table behavior  | focused Table keyboard contract                                                                               | aria-sort and keyboard cycle remain green                               |
+| Full accessibility       | `PWTEST_SKIP_BUILD=1 ./node_modules/.bin/playwright test tests/a11y` against the built Ladle output           | full suite passes; report neutral/UZH separately if applicable          |
+| Security                 | bounded `$security-review` over the exact implementation range                                                | no unverified high-confidence issue; pre-existing findings separated    |
+| Maintainability          | mandatory `$thermo-nuclear-code-quality-review` over the exact final range                                    | pass or verified findings resolved                                      |
+| Independent final review | opposing provider or `agy` where available; current-provider fallback recorded if unavailable                 | no unresolved blocking finding                                          |
+| Forge/CI                 | required checks on the draft PR                                                                               | green before ready-for-review; do not merge in this goal                |
+
+## Review and publication routing
+
+- Review exact commits, not a moving worktree. Commit the plan first and give
+  reviewers the exact range for every slice.
+- Use the configured current-provider reviewer for W0/W1/W2/W3 and a separate
+  simplification pass after each implementation review. Verify every finding
+  against the live source before changing code.
+- Run the mandatory final security and thermo-nuclear maintainability gates on
+  the complete A3 range. Add an independent opposing-provider review at final
+  close-out when it can inspect the live range; otherwise record the fallback.
+- Once all local gates pass, submit one draft PR targeting `v5` with the
+  conventional title `feat(refs): complete v5 composite ref contracts` (or
+  the repository's equivalent native-stack title). Update the whole-branch
+  description with `$rs-mr-description-writer`, exact test evidence, changed
+  public contracts, migration notes, and the explicit no-main boundary.
+- Keep the PR draft until the user separately authorizes ready-for-review.
+  This goal does not authorize merge, queue, tag, release, package publish,
+  worktree cleanup, branch deletion, or any operation involving `main`.
+
+## Risks and mitigations
+
+| Risk                                                           | Mitigation                                                                                                                           |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| A ref lands on a wrapper, portal, or decorative root           | Type each target concretely and assert `document.activeElement` against the visible control.                                         |
+| Radix `asChild` creates a polymorphic target                   | Exclude Modal/Tooltip and reject/widen nothing; stop on any target not proven stable.                                                |
+| DateTimePicker consumers use `.value` on the old pseudo-handle | Search repository consumers and stop at D3 if a real dependency is found; controlled `value` remains the documented source of truth. |
+| Table's imperative handle is mistaken for a DOM ref            | Export `TableRef`, reject HTML element refs, and test `reset()` explicitly.                                                          |
+| Composite state or keyboard behavior regresses                 | Run focused open/select/close/focus-return contracts plus the full a11y suite and existing Table keyboard test.                      |
+| Broad scope becomes a redesign                                 | Keep changes to prop/ref threading, docs, tests, and generated declarations; defer any visual or structural redesign.                |
+| Tooling output is falsely interpreted                          | Read producing logs/counters, separate pnpm signature warnings from test failures, and never call an unrun check green.              |
+
+## Progress (append-only)
+
+- 2026-08-02: Verified `v5`, `origin/v5`, and the A3 placeholder at
+  `b7d72b5f`; confirmed A1/A2 PRs #186/#187 merged into `v5`, no A3 PR, clean
+  dedicated worktree, ignored `trees/`, and explicit prohibition on `main`.
+- 2026-08-02: Sol independently reviewed the live source and returned
+  `DONE_WITH_CONCERNS`. The concern and accepted resolution are recorded in
+  “Sol's independent inventory and decision”: A3 includes the twelve stable
+  DOM composites plus Table, while deprecated, passive, polymorphic, and
+  multi-target surfaces remain excluded.
+- 2026-08-02: Plan authored as the first A3 branch change. Implementation,
+  review, final gates, and draft PR publication remain pending.


### PR DESCRIPTION
## What This Adds

This is the standalone Stack A3 layer for the `v5` release branch, after A1
and A2 landed. It gives the remaining stable composite controls a concrete
React 19 `ref` target and replaces Table's ad hoc ref prop with a typed
imperative handle.

- Adds DOM refs for Checkbox, Switch, Slider, Collapsible, Dropdown,
  MultiSelect, SelectField, AlphaNumericPinField, ColorPicker, DatePicker,
  DateRangePicker, and DateTimePicker.
- Adds `TableRef.reset()` and removes the public `forwardedRef` prop.
- Replaces DateTimePicker's pseudo-handle with the actual calendar trigger;
  `DateTimePickerRef` remains an `HTMLButtonElement` type alias.
- Adds migration guidance, a consumer-facing Ladle contract story, durable
  type fixtures, focus and interaction tests, and an optional Slider
  `ariaLabel` for naming the thumb.

## How It Works

- Each DOM ref is passed directly to the one stable focusable element owned by
  the component or its existing Radix/Button/input-otp primitive.
- `SelectField` delegates its ref to the underlying Select trigger. The OTP
  ref reaches the real input, and Slider reaches its thumb.
- Table exposes only `reset()` through `useImperativeHandle`; it does not
  pretend to be an HTML table ref.
- The contract story exercises focus, open and close, selection, and focus
  return. The Table story proves sorting and reset behavior.

## Important Details

- Deprecated Formik wrappers, polymorphic Modal/Tooltip triggers, multi-target
  composites, passive components, and raw primitives remain out of scope.
- The old DateTimePicker ref `.value` property is removed. Consumers should
  read the selected date from controlled `value` and `onChange` state.
- This branch targets `v5` only. It does not target or merge into `main`, and
  it does not publish a package, tag a release, or alter generated `dist`.

## Branch Coverage

- Base: `v5` at `b7d72b5f309594ebfb02261c1fb35e85345a88bd`
- Head: `7afe5f4cb12b0ceed36a41259dd96cae8c46d54b`
- Reviewed: 12 commits, 20 files changed, 1,460 additions and 253 deletions.
- Plan: [`project/2026-08-02-v5-composite-refs-plan.md`](project/2026-08-02-v5-composite-refs-plan.md)
- Covered: the three plan-boundary commits, concrete composite refs, Table
  migration, DateTimePicker correction, migration docs, type/runtime stories,
  accessibility follow-up, final review evidence, package-manager warning
  record, and the formatter-only correction after the first forge run.

## Review Focus

- Check that every ref lands on the documented interactive target rather than
  a wrapper or portal.
- Review the distinction between DOM refs and `TableRef`, especially the
  negative type cases.
- Review DateTimePicker compatibility guidance and the removal of the
  pseudo-handle value.
- Review the stateful selection and focus-return proof plus the new story's
  accessible naming.

## Verification

The last semantic code commit is `45e11f5b`. `ef0e29bb` then applies the
repository formatter's class-order output to seven touched sources, followed
by append-only plan entries recording the formatter, review, and forge gates:

- `tsc --noEmit` and `tsc -p tsconfig.types.json --noEmit` -> pass.
- `tsc -b`, Vite declaration build, and `tsx src/copy.ts` -> pass.
- Ladle production build -> pass; metadata contains the composite and Table
  contract stories.
- Composite ref Playwright contract -> 4/4 pass.
- Existing keyboard and direct-control contracts -> 16/16 pass.
- Full `tests/a11y` suite -> 772/772 pass across neutral and UZH themes.
- Changed-file ESLint -> pass with zero warnings.
- Generated declarations contain concrete DOM ref types, `DateTimePickerRef`
  as `HTMLButtonElement`, and `TableRef`; generated output remains ignored.
- Bounded security review over `b7d72b5f..2b9816a2` -> no high-confidence
  exploitable findings.
- Thermo-nuclear maintainability review over `b7d72b5f..2b9816a2` -> no
  blocking or reportable findings.
- Local Prettier check for all seven files named by the initial forge failure
  -> pass after `ef0e29bb`.
- Forge CI run `30745732421` -> all checks pass: formatting, types, lint, smoke
  Test (`460 passed`), four A11y shards (`193 passed` each), Greptile, and the
  build-only `Build and Publish` job. Its npm publish and dist-tag steps were
  skipped.

Failed/Warning:

- `pnpm --dir packages/design-system check` stopped before running because
  `pnpm@10.30.0` could not fetch or verify its npm registry signatures. The
  installed binaries above were used without changing the lockfile or
  overriding the signature policy.
- The initial forge formatting job failed on seven touched files; the
  repository formatter was applied narrowly in `ef0e29bb`, and the rerun is
  green. No whole-file reformat was introduced.

## Visual Evidence

No screenshot artifact is included. This branch changes ref wiring and
contract proof, not component visuals; the rebuilt Ladle stories and browser
checks cover the changed states.

## Security / Privacy

- No high-confidence security finding was identified in the bounded review.
- No secrets, private payloads, personal data, or generated release artifacts
  are included.

## Blocking Before Merge

- [ ] GitHub CI and reviewer approval for this draft PR.
- [ ] Keep the merge target on `v5`; do not merge or promote to `main`.

## Follow-Up After Merge

- Toggle the PR ready only after the forge checks and review are green.
- Keep the pnpm registry-signature issue as a separate tooling follow-up.
