### PR TITLE
feat(selectors)!: unify v5 test selector contract on table and workflow

### DIFF
--- a/packages/design-system/MIGRATION.md
+++ b/packages/design-system/MIGRATION.md
@@ -284,8 +284,10 @@ prop and `onChange` callback instead.
 ### Test selectors: `data={{ cy, test }}`
 
 v5 standardises the **shape** of every test selector: `{ cy?: string; test?:
-string }`, rendered as `data-cy` and `data-test`. There is no `data-testid` and
-no arbitrary attribute record.
+string }`, rendered as `data-cy` and `data-test`. No selector prop accepts
+`data-testid` or an arbitrary attribute record. Some component stories still
+show a `data-testid` form in their examples; those docs are stale and are being
+corrected — the prop types above are authoritative.
 
 Where a composite has one obvious target, the prop is named `data`. Components
 with several independently addressable controls keep their named per-element

--- a/packages/design-system/MIGRATION.md
+++ b/packages/design-system/MIGRATION.md
@@ -281,6 +281,51 @@ type-only imports remain useful, but the old pseudo-handle's Date-valued
 `.value` property is gone. Read the selected date from the controlled `value`
 prop and `onChange` callback instead.
 
+### Test selectors: `data={{ cy, test }}`
+
+v5 has one selector convention across the composites: an optional `data` prop
+whose `cy` and `test` fields render as `data-cy` and `data-test`. There is no
+`data-testid` and no arbitrary attribute record.
+
+`Table` is the last composite to adopt it, which required freeing the `data`
+name. **Its row collection moved to `rows` and its selector prop is now
+`data`** — both halves of the rename land together, so a partially migrated
+call site fails to compile rather than silently passing rows as selectors:
+
+```tsx
+// before
+<Table data={rows} dataAttributes={{ cy: 'results', test: 'results' }} />
+// after
+<Table rows={rows} data={{ cy: 'results', test: 'results' }} />
+```
+
+The attributes stay on the composite's outer root, which is the stable table
+selector. Sortable header buttons are addressed by role (`columnheader` →
+`button`), not by a second selector API.
+
+`Workflow` and `WorkflowProgress` steps are independently actionable, so their
+selectors are per step rather than on the list:
+
+```tsx
+<Workflow
+  activeIx={0}
+  onClick={handleClick}
+  items={[
+    { title: 'Draft', data: { cy: 'step-draft' } },
+    {
+      title: 'Review',
+      tooltip: 'Not yet available',
+      data: { cy: 'step-review' },
+    },
+  ]}
+/>
+```
+
+The attributes render on each step's `<button>` in both the tooltip and plain
+paths, and a disabled step keeps them on that same focusable button. The `<ol>`
+root intentionally carries no selector, since no single one would identify a
+step. The step object passed to `onClick` is unchanged.
+
 ## Peer dependencies
 
 v5 no longer bundles its runtime libraries — every one is declared as a **peer

--- a/packages/design-system/MIGRATION.md
+++ b/packages/design-system/MIGRATION.md
@@ -283,14 +283,22 @@ prop and `onChange` callback instead.
 
 ### Test selectors: `data={{ cy, test }}`
 
-v5 has one selector convention across the composites: an optional `data` prop
-whose `cy` and `test` fields render as `data-cy` and `data-test`. There is no
-`data-testid` and no arbitrary attribute record.
+v5 standardises the **shape** of every test selector: `{ cy?: string; test?:
+string }`, rendered as `data-cy` and `data-test`. There is no `data-testid` and
+no arbitrary attribute record.
 
-`Table` is the last composite to adopt it, which required freeing the `data`
-name. **Its row collection moved to `rows` and its selector prop is now
-`data`** — both halves of the rename land together, so a partially migrated
-call site fails to compile rather than silently passing rows as selectors:
+Where a composite has one obvious target, the prop is named `data`. Components
+with several independently addressable controls keep their named per-element
+props (`Modal`'s `dataContent`/`dataCloseButton`/`dataPrimaryAction`, the
+pickers' `dataTrigger`/`dataCalendar`/…, `Slider`'s `dataThumb`,
+`Tooltip`'s `dataContent`), which now all carry that same value shape. Many
+composites still expose no selector prop at all; those are unchanged.
+
+`Table` was the last composite still using the old `dataAttributes` name.
+Adopting `data` required freeing that name. **Its row collection moved to
+`rows` and its selector prop is now `data`** — both halves of the rename land
+together, so a partially migrated call site fails to compile rather than
+silently passing rows as selectors:
 
 ```tsx
 // before

--- a/packages/design-system/src/PublicContracts.stories.mdx
+++ b/packages/design-system/src/PublicContracts.stories.mdx
@@ -1,11 +1,16 @@
 import Button from './Button'
 import Navigation from './Navigation'
 import Progress from './Progress'
+import Table from './Table'
+import Workflow from './Workflow'
 
 {/* START README */}
 <div className="prose prose-sm max-w-none">
 This story exercises the narrowed public prop contracts for Button, Navigation,
-and Progress with representative native, ARIA, and data attributes.
+and Progress with representative native, ARIA, and data attributes. It also
+pins the v5 selector contract: `Table` carries its selectors on the composite
+root through `data`, while `Workflow` and `WorkflowProgress` carry per-step
+selectors on each step's own button, including the tooltip and disabled paths.
 </div>
 {/* END README */}
 
@@ -36,6 +41,63 @@ export const Default = () => (
       value={50}
       max={100}
       formatter={(value) => value}
+    />
+    <Table
+      data={{ cy: 'contract-table', test: 'contract-table' }}
+      caption="Contract table"
+      columns={[
+        { label: 'Count', accessor: 'count', sortable: true },
+        { label: 'Answer', accessor: 'answer', sortable: false },
+      ]}
+      rows={[
+        { count: 2, answer: 'Second' },
+        { count: 1, answer: 'First' },
+      ]}
+    />
+    <Workflow
+      activeIx={0}
+      disabledFrom={2}
+      onClick={() => undefined}
+      items={[
+        {
+          title: 'Plain step',
+          data: { cy: 'contract-step-plain', test: 'contract-step-plain' },
+        },
+        {
+          title: 'Tooltip step',
+          tooltip: 'Contract tooltip',
+          data: { cy: 'contract-step-tooltip', test: 'contract-step-tooltip' },
+        },
+        {
+          title: 'Disabled step',
+          tooltipDisabled: 'Contract disabled tooltip',
+          data: {
+            cy: 'contract-step-disabled',
+            test: 'contract-step-disabled',
+          },
+        },
+      ]}
+    />
+    <Workflow
+      onClick={() => undefined}
+      items={[
+        {
+          title: 'Progress step',
+          progress: 0.5,
+          data: {
+            cy: 'contract-progress-step',
+            test: 'contract-progress-step',
+          },
+        },
+        {
+          title: 'Progress tooltip step',
+          tooltip: 'Contract progress tooltip',
+          data: {
+            cy: 'contract-progress-tooltip',
+            test: 'contract-progress-tooltip',
+          },
+        },
+      ]}
     />
   </div>
 )

--- a/packages/design-system/src/Table.stories.mdx
+++ b/packages/design-system/src/Table.stories.mdx
@@ -23,9 +23,9 @@ The component supports column-based configuration, data transformers for preproc
 The Table component accepts the following props:
 
 - @param id - The id of the table.
-- @param dataAttributes - The object of data attributes that can be used for testing (e.g. data-test or data-cy)
+- @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy)
 - @param columns - The columns of the table. The columns are defined by an array of objects where each object has a label, an accessor and optional transformer and formatters.
-- @param data - The data of the table. The data is defined by an array of objects where each object has a key-value pair for each column.
+- @param rows - The rows of the table. The rows are defined by an array of objects where each object has a key-value pair for each column.
 - @param caption - The optional caption of the table.
 - @param ref - The optional ref object allows you to access the table methods.
 - @param className - The optional className object allows you to override the default styling.
@@ -59,9 +59,9 @@ Available Stories:
 Props (Table component):
 
 - id?: string - HTML id attribute for the table
-- dataAttributes?: Record<string, string> - Data attributes for testing
+- data?: { cy?: string, test?: string } - Data attributes for testing
 - columns: ColumnDefinition[] - Column configuration array
-- data: DataRow[] - Array of data objects to display
+- rows: DataRow[] - Array of row objects to display
 - caption?: string - Accessible table caption
 - ref?: React.Ref - Reference to table for method access
 - className?: {
@@ -102,7 +102,7 @@ Usage Examples:
     { label: 'Age', accessor: 'age', sortable: true },
     { label: 'Email', accessor: 'email', sortable: false }
   ]}
-  data={[
+  rows={[
     { name: 'John Doe', age: 30, email: 'john@example.com' },
     { name: 'Jane Smith', age: 25, email: 'jane@example.com' }
   ]}
@@ -129,7 +129,7 @@ Usage Examples:
       )
     }
   ]}
-  data={salesData}
+  rows={salesData}
   defaultSortField="revenue"
   defaultSortOrder="desc"
 />
@@ -137,7 +137,7 @@ Usage Examples:
 // With custom styling
 <Table
   columns={columns}
-  data={data}
+  rows={data}
   className={{
     root: 'rounded-lg shadow-sm border',
     tableHeader: 'bg-gray-50 border-b',
@@ -157,7 +157,7 @@ const tableRef = useRef(null)
   <Table
     ref={tableRef}
     columns={columns}
-    data={data}
+    rows={data}
   />
 </>
 
@@ -179,7 +179,7 @@ interface UserData {
       formatter: ({ row }) => formatDistanceToNow(row.lastLogin)
     }
   ]}
-  data={userData}
+  rows={userData}
 />
 ```
 
@@ -220,7 +220,7 @@ export const Simple = () => {
           { label: 'Answer', accessor: 'answer', sortable: true },
           { label: 'Username', accessor: 'username', sortable: false },
         ]}
-        data={data}
+        rows={data}
         caption="Table with example data"
       />
     </div>
@@ -241,7 +241,7 @@ export const DefaultSorting = () => {
           { label: 'Answer', accessor: 'answer', sortable: true },
           { label: 'Username', accessor: 'username', sortable: false },
         ]}
-        data={data}
+        rows={data}
         caption="Table with example data"
         defaultSortField="count"
         defaultSortOrder="desc"
@@ -260,7 +260,7 @@ export const Sorting = () => {
       />
       <Table
         columns={[{ label: 'Count', accessor: 'count', sortable: true }]}
-        data={[{ count: 100 }, { count: -50 }, { count: -70 }, { count: 30 }]}
+        rows={[{ count: 100 }, { count: -50 }, { count: -70 }, { count: 30 }]}
         caption="Table with example data"
       />
     </div>
@@ -298,7 +298,7 @@ return (
       { label: 'Answer', accessor: 'answer', sortable: true },
       { label: 'Username', accessor: 'username', sortable: false },
     ]}
-    data={data}
+    rows={data}
     caption="Table with example data"
     ref={ref}
   />
@@ -334,7 +334,7 @@ export const Formatted = () => {
           },
           { label: 'Username', accessor: 'username', sortable: false },
         ]}
-        data={[
+        rows={[
           {
             className: 'text-foreground',
             ...data[0],
@@ -380,7 +380,7 @@ export const Combined = () => {
           },
           { label: 'Username', accessor: 'username', sortable: false },
         ]}
-        data={data}
+        rows={data}
         caption="Table with example data"
         className={{
           root: 'bg-white',

--- a/packages/design-system/src/Table.tsx
+++ b/packages/design-system/src/Table.tsx
@@ -36,12 +36,12 @@ export type ColumnType<RowType> = {
 
 export interface TableProps<RowType extends BaseRowType> {
   id?: string
-  dataAttributes?: {
+  data?: {
     cy?: string
     test?: string
   }
   columns: ColumnType<RowType>[]
-  data: RowType[]
+  rows: RowType[]
   caption?: string
   className?: {
     root?: string
@@ -58,13 +58,13 @@ export interface TableProps<RowType extends BaseRowType> {
 /**
  * This function returns a pre-styled Table component based on the RadixUI table component and the custom theme.
  * The table is sortable by clicking on the column header.
- * Before the table is being sorted according to the sorting parameters, the transformer will be applied to the data.
+ * Before the table is being sorted according to the sorting parameters, the transformer will be applied to the rows.
  * The formatter is meant to be used for visual modifications of the fields and applied after sorting.
  *
  * @param id - The id of the table.
- * @param dataAttributes - The object of data attributes that can be used for testing (e.g. data-test or data-cy)
+ * @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy)
  * @param columns - The columns of the table. The columns are defined by an array of objects where each object has a label, an accessor and optional transformer and formatters.
- * @param data - The data of the table. The data is defined by an array of objects where each object has a key-value pair for each column.
+ * @param rows - The rows of the table. The rows are defined by an array of objects where each object has a key-value pair for each column.
  * @param caption - The optional caption of the table.
  * @param ref - The optional ref object allows you to access the table methods.
  * @param className - The optional className object allows you to override the default styling.
@@ -77,9 +77,9 @@ export function Table<
   RowType extends Record<string, string | number | boolean>,
 >({
   id,
-  dataAttributes,
-  columns,
   data,
+  columns,
+  rows,
   caption,
   className,
   ref,
@@ -108,7 +108,7 @@ export function Table<
   }
 
   const tableData = useMemo(() => {
-    const transformedData = data.map(
+    const transformedData = rows.map(
       (row, index) =>
         columns
           .map((col) =>
@@ -178,7 +178,7 @@ export function Table<
         })}
       </tr>
     ))
-  }, [data, columns, sortField, order, className, emptyCellText])
+  }, [rows, columns, sortField, order, className, emptyCellText])
 
   return (
     <div
@@ -187,8 +187,8 @@ export function Table<
         className?.root
       )}
       id={id}
-      data-cy={dataAttributes?.cy}
-      data-test={dataAttributes?.test}
+      data-cy={data?.cy}
+      data-test={data?.test}
     >
       <table className="w-full table-auto border-collapse text-sm">
         {caption && (

--- a/packages/design-system/src/Workflow.stories.mdx
+++ b/packages/design-system/src/Workflow.stories.mdx
@@ -21,7 +21,7 @@ Key features include progress indicators, disabled states for future steps, cust
 
 The workflow component accepts the following props:
 
-- @param items - The array of steps that should be displayed in the workflow.
+- @param items - The array of steps that should be displayed in the workflow. Each step accepts an optional `data` object with `cy` and `test` fields, whose attributes are rendered on that step's button.
 - @param onClick - The function that is called when a step is clicked. The step object is passed as an argument.
 - @param activeIx - The index of the active step. State management is not handled by this component.
 - @param twStyles - The optional twStyles object allows you to override the default styling.
@@ -57,8 +57,9 @@ Available Stories:
 Props:
 
 - items: Array of step objects (StepProps or StepProgressProps)
-  - StepProps: { title, description?, tooltip?, tooltipDisabled? }
-  - StepProgressProps: { title, description?, tooltip?, tooltipDisabled?, progress?, completed?, error? }
+  - StepProps: { title, description?, tooltip?, tooltipDisabled?, data? }
+  - StepProgressProps: { title, description?, tooltip?, tooltipDisabled?, data?, progress?, completed?, error? }
+  - data?: { cy?: string, test?: string } - Selector attributes rendered on that step's button
 - onClick: (item, index) => void - Handler for step clicks
 - activeIx?: number - Currently active step index (required for basic workflow, optional for progress workflow)
 - twStyles?: Object with bgHover, bgActive, bgPast for color customization

--- a/packages/design-system/src/Workflow.tsx
+++ b/packages/design-system/src/Workflow.tsx
@@ -15,6 +15,12 @@ interface StepBaseProps {
   description?: string
   tooltip?: string
   tooltipDisabled?: string
+  // Selectors are per-step because each step is an independently actionable
+  // button; the `<ol>` root deliberately has no single selector.
+  data?: {
+    cy?: string
+    test?: string
+  }
   progress?: number
   completed?: boolean
   error?: boolean
@@ -67,7 +73,7 @@ export interface WorkflowProgressProps extends WorkflowBaseProps {
 /**
  * This function returns a pre-styled Workflow component. Theme-based styling is not available for this component at the moment, use the twStyles or className objects instead to override default styling.
  *
- * @param items - The array of steps that should be displayed in the workflow.
+ * @param items - The array of steps that should be displayed in the workflow. Each step accepts an optional data object ({ cy, test }) whose attributes are rendered on that step's button.
  * @param onClick - The function that is called when a step is clicked. The step object is passed as an argument.
  * @param activeIx - The index of the active step. State management is not handled by this component.
  * @param twStyles - The optional twStyles object allows you to override the default styling.
@@ -250,6 +256,10 @@ export function WorkflowItem({
     // focusable so keyboard users can still read its `tooltipDisabled`
     // explanation. The runtime guard above already blocks the action.
     'aria-disabled': disabled || undefined,
+    // The selector belongs on the button in both the tooltip and the plain
+    // path, so a disabled step stays addressable through the same element.
+    'data-cy': item.data?.cy,
+    'data-test': item.data?.test,
   } as const
 
   return (

--- a/packages/design-system/tests/contracts/composite-refs.types.ts
+++ b/packages/design-system/tests/contracts/composite-refs.types.ts
@@ -273,18 +273,18 @@ const tableRef = (value: TableRef | null) => {
 
 acceptsTableProps({
   columns: [{ accessor: 'name', label: 'Name' }],
-  data: [{ name: 'Ada' }],
+  rows: [{ name: 'Ada' }],
   ref: tableRef,
 })
 acceptsTableProps({
   columns: [{ accessor: 'name', label: 'Name' }],
-  data: [{ name: 'Ada' }],
+  rows: [{ name: 'Ada' }],
   // @ts-expect-error Table refs expose the imperative TableRef, not the DOM table element.
   ref: wrongTableObjectRef,
 })
 acceptsTableProps({
   columns: [{ accessor: 'name', label: 'Name' }],
-  data: [{ name: 'Ada' }],
+  rows: [{ name: 'Ada' }],
   // @ts-expect-error Table's removed forwardedRef alias must not compile.
   forwardedRef: tableRef,
 })

--- a/packages/design-system/tests/contracts/test-selectors.types.ts
+++ b/packages/design-system/tests/contracts/test-selectors.types.ts
@@ -1,0 +1,87 @@
+import type {
+  TableProps,
+  WorkflowProgressProps,
+  WorkflowProps,
+} from '../../src'
+
+type Row = { count: number; answer: string; className?: string }
+
+const columns = [
+  { label: 'Count', accessor: 'count', sortable: true },
+  { label: 'Answer', accessor: 'answer' },
+]
+
+const rows: Row[] = [{ count: 1, answer: 'First' }]
+
+function acceptsTableProps(props: TableProps<Row>) {
+  return props
+}
+
+acceptsTableProps({ columns, rows })
+acceptsTableProps({ columns, rows, data: { cy: 'table', test: 'table' } })
+acceptsTableProps({ columns, rows, data: { cy: 'table' } })
+acceptsTableProps({ columns, rows, data: { test: 'table' } })
+
+// @ts-expect-error Rows are passed through `rows`; `data` now carries selectors.
+acceptsTableProps({ columns, data: rows })
+
+// @ts-expect-error `dataAttributes` was renamed to `data` in v5.
+acceptsTableProps({ columns, rows, dataAttributes: { cy: 'table' } })
+
+acceptsTableProps({
+  columns,
+  rows,
+  // @ts-expect-error The selector contract is exactly `{ cy, test }`.
+  data: { testid: 'table' },
+})
+
+acceptsTableProps({
+  columns,
+  rows,
+  // @ts-expect-error `data-testid` is not part of the v5 selector contract.
+  data: { 'data-testid': 'table' },
+})
+
+function acceptsWorkflowProps(props: WorkflowProps) {
+  return props
+}
+
+acceptsWorkflowProps({
+  activeIx: 0,
+  items: [{ title: 'Step', data: { cy: 'step', test: 'step' } }],
+  onClick: () => undefined,
+})
+
+acceptsWorkflowProps({
+  activeIx: 0,
+  // @ts-expect-error Step selectors use the `{ cy, test }` shape only.
+  items: [{ title: 'Step', data: { testid: 'step' } }],
+  onClick: () => undefined,
+})
+
+acceptsWorkflowProps({
+  activeIx: 0,
+  // @ts-expect-error Step selectors are an object, not a bare string.
+  items: [{ title: 'Step', data: 'step' }],
+  onClick: () => undefined,
+})
+
+function acceptsWorkflowProgressProps(props: WorkflowProgressProps) {
+  return props
+}
+
+acceptsWorkflowProgressProps({
+  items: [
+    { title: 'Step', progress: 0.5, data: { cy: 'step', test: 'step' } },
+    { title: 'Done', completed: true, data: { test: 'done' } },
+  ],
+  onClick: () => undefined,
+})
+
+acceptsWorkflowProgressProps({
+  items: [
+    // @ts-expect-error Step selectors use the `{ cy, test }` shape only.
+    { title: 'Step', progress: 0.5, data: { 'data-testid': 'step' } },
+  ],
+  onClick: () => undefined,
+})

--- a/packages/design-system/tests/contracts/test-selectors.types.ts
+++ b/packages/design-system/tests/contracts/test-selectors.types.ts
@@ -22,8 +22,10 @@ acceptsTableProps({ columns, rows, data: { cy: 'table', test: 'table' } })
 acceptsTableProps({ columns, rows, data: { cy: 'table' } })
 acceptsTableProps({ columns, rows, data: { test: 'table' } })
 
+// `rows` is supplied so the only available error is the selector/row mix-up
+// itself, not an incidental missing-prop error.
 // @ts-expect-error Rows are passed through `rows`; `data` now carries selectors.
-acceptsTableProps({ columns, data: rows })
+acceptsTableProps({ columns, rows, data: rows })
 
 // @ts-expect-error `dataAttributes` was renamed to `data` in v5.
 acceptsTableProps({ columns, rows, dataAttributes: { cy: 'table' } })

--- a/packages/design-system/tests/smoke/test-selectors.spec.ts
+++ b/packages/design-system/tests/smoke/test-selectors.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test'
+
+import { gotoStory } from '../_support/ladle'
+
+const story = 'public-contracts--default'
+
+// The v5 selector contract: `data={{ cy, test }}` renders `data-cy`/`data-test`
+// on the element a test would actually drive. For Table that is the composite
+// root; for Workflow it is each step's own button, never the decorative `<li>`
+// or the Tooltip wrapper.
+test.describe('selector contract', () => {
+  test('renders Table selectors on the composite root', async ({ page }) => {
+    await gotoStory(page, story)
+
+    const table = page.locator('[data-cy="contract-table"]')
+    await expect(table).toHaveCount(1)
+    await expect(table).toHaveAttribute('data-test', 'contract-table')
+    // The root is the wrapper that owns the table, not the <table> itself.
+    await expect(table.locator('table')).toHaveCount(1)
+    await expect(
+      page.getByRole('table', { name: 'Contract table' })
+    ).toBeVisible()
+
+    // Sorting stays discoverable by role and keeps working under the rename.
+    const sortHeader = page.getByRole('columnheader', { name: 'Count' })
+    await expect(sortHeader).toHaveAttribute('aria-sort', 'none')
+    await sortHeader.getByRole('button').click()
+    await expect(sortHeader).toHaveAttribute('aria-sort', 'ascending')
+    await expect(page.locator('[data-cy="contract-table"] tbody tr').first()) //
+      .toContainText('First')
+  })
+
+  test('renders Workflow step selectors on each step button', async ({
+    page,
+  }) => {
+    await gotoStory(page, story)
+
+    const cases = [
+      'contract-step-plain',
+      'contract-step-tooltip',
+      'contract-step-disabled',
+      'contract-progress-step',
+      'contract-progress-tooltip',
+    ] as const
+
+    for (const selector of cases) {
+      const step = page.locator(`[data-cy="${selector}"]`)
+      await expect(step).toHaveCount(1)
+      await expect(step).toHaveAttribute('data-test', selector)
+      // The selector-bearing element is the button itself in every branch,
+      // including the tooltip path where a Radix trigger wraps the content.
+      await expect(step).toHaveJSProperty('tagName', 'BUTTON')
+    }
+
+    // A disabled step keeps the selector on its focusable button so the
+    // disabled-state tooltip stays reachable.
+    const disabled = page.locator('[data-cy="contract-step-disabled"]')
+    await expect(disabled).toHaveAttribute('aria-disabled', 'true')
+    await disabled.focus()
+    await expect(disabled).toBeFocused()
+
+    // The list root deliberately carries no single ambiguous selector.
+    const listRoots = page.getByRole('list')
+    await expect(listRoots.first()).not.toHaveAttribute('data-cy', /.*/)
+  })
+})

--- a/packages/design-system/tests/smoke/test-selectors.spec.ts
+++ b/packages/design-system/tests/smoke/test-selectors.spec.ts
@@ -59,8 +59,16 @@ test.describe('selector contract', () => {
     await disabled.focus()
     await expect(disabled).toBeFocused()
 
-    // The list root deliberately carries no single ambiguous selector.
-    const listRoots = page.getByRole('list')
-    await expect(listRoots.first()).not.toHaveAttribute('data-cy', /.*/)
+    // The list roots deliberately carry no single ambiguous selector. Anchor on
+    // the workflows themselves rather than document order, so adding another
+    // list to this shared contract story cannot silently retarget the guard.
+    const listRoots = page.locator(
+      'ol:has([data-cy^="contract-step"]), ol:has([data-cy^="contract-progress"])'
+    )
+    await expect(listRoots).toHaveCount(2)
+    for (const root of await listRoots.all()) {
+      await expect(root).not.toHaveAttribute('data-cy', /.*/)
+      await expect(root).not.toHaveAttribute('data-test', /.*/)
+    }
   })
 })

--- a/packages/design-system/tsconfig.types.json
+++ b/packages/design-system/tsconfig.types.json
@@ -8,6 +8,7 @@
   "include": [
     "tests/contracts/public-contracts.types.ts",
     "tests/contracts/direct-control-refs.types.ts",
-    "tests/contracts/composite-refs.types.ts"
+    "tests/contracts/composite-refs.types.ts",
+    "tests/contracts/test-selectors.types.ts"
   ]
 }

--- a/project/2026-08-02-v5-post-a3-next-roadmap.md
+++ b/project/2026-08-02-v5-post-a3-next-roadmap.md
@@ -3,8 +3,8 @@
 ## Identity and operating contract
 
 - Date: 2026-08-02
-- Status: roadmap committed; W1 is prepared but paused at an explicit public
-  API naming gate discovered by the delegated executor and confirmed by Sol.
+- Status: roadmap committed; the Table naming gate is ruled (option A) and W1 is
+  in execution.
 - Repository: `uzh-bf/design-system`
 - Release trunk: `v5` (long-lived branch and final merge target).
 - Current base: `origin/v5` at `77db88226e8c2fd14a59ca4e73ae869b5499a43d`, the
@@ -117,21 +117,23 @@ data?: {
 }
 ```
 
-- `Table`: its current public props are `data: RowType[]` (rows) and
+- `Table`: its current public props were `data: RowType[]` (rows) and
   `dataAttributes: { cy?: string; test?: string }` (selector). A literal
   `dataAttributes` → `data` rename cannot compile while the row prop remains
-  named `data`. This is a decision gate, not an executor guess:
+  named `data`.
 
-  | Option | Result | Recommendation |
-  | --- | --- | --- |
-  | A — rename rows to `rows` and selectors to `data` together | One coherent selector vocabulary, but a second breaking Table API rename; requires every in-repository Table call site and migration example to change | Recommended only if the user explicitly accepts the wider v5 break |
-  | B — keep Table's `dataAttributes` for now and implement Workflow's item-level `data` | Smallest safe PR, but the public selector vocabulary remains inconsistent and Table becomes a follow-up | Safe fallback if the wider Table break is not approved |
-  | C — use another selector name on Table | Avoids the collision but creates a third public convention | Reject |
+  **Ruling (2026-08-02, user): option A.** Rename the row prop `data` → `rows`
+  and the selector prop `dataAttributes` → `data` in the same change, so Table
+  matches the `data={{ cy, test }}` convention already used by Button,
+  Checkbox, Progress, and the other v5 composites. The recorded blast radius
+  was overstated: `Table` is referenced only in `Table.tsx`,
+  `Table.stories.mdx`, and `MIGRATION.md`, and v5 has no consumers, so the
+  rename is cheap now and expensive after GA. Options B (Workflow-only, Table
+  deferred) and C (a third selector name) are rejected.
 
-  Do not implement A or silently choose B until the ruling is recorded. Under
-  option A, keep selector attributes on the existing outer root; this root is
-  the stable table selector and sortable header buttons remain discoverable by
-  role rather than receiving an ad-hoc second selector API.
+  Selector attributes stay on the existing outer root; this root is the stable
+  table selector and sortable header buttons remain discoverable by role rather
+  than receiving an ad-hoc second selector API.
 - `Workflow`: each step is an independently actionable button. Add the same
   optional `data` value to the step item shape and render its `data-cy` and
   `data-test` on that step's actual `<button>` in both tooltip and non-tooltip
@@ -157,8 +159,8 @@ needed by the repository's existing contract-test convention):
   generic test page)
 - `packages/design-system/tests/smoke/test-selectors.spec.ts`
 - `packages/design-system/tests/contracts/test-selectors.types.ts`
-- `packages/design-system/tests/contracts/composite-refs.types.ts` only if
-  option A requires updating existing Table call-site type fixtures
+- `packages/design-system/tests/contracts/composite-refs.types.ts` to update the
+  existing Table call-site type fixtures for the option A rename
 - `packages/design-system/tsconfig.types.json` only if the type fixture needs
   an existing project include adjustment
 - `packages/design-system/MIGRATION.md` for the `dataAttributes` → `data`
@@ -177,10 +179,9 @@ Formik modules, or the broader selector inventory in W1.
    assert that a disabled step remains the selector-bearing button rather than
    a wrapper.
 3. A type fixture accepts the exact `cy`/`test` shape and rejects arbitrary
-   keys (especially `data-testid`). If option A is approved, it also rejects
+   keys (especially `data-testid`). Under the ruled option A it also rejects
    the removed Table `dataAttributes` prop and row arrays passed through
-   `Table.data`; if option B is chosen, the Table assertion remains a tracked
-   follow-up instead of being faked.
+   `Table.data`.
 4. Existing keyboard and accessibility behavior remains intact: Workflow
    buttons remain focusable, disabled steps retain `aria-disabled`, and Table
    sorting/`aria-sort` behavior is unchanged.
@@ -332,3 +333,26 @@ review. Publication and PR readiness remain orchestrator/user decisions.
   that `tests/contracts` is not CI-enforced. Kimi was stopped before editing;
   W1 now awaits the explicit Table naming ruling and will place runtime proof
   under `tests/smoke`.
+- 2026-08-02: takeover session re-verified `origin/v5` at `77db8822`, the clean
+  `rs/v5-test-selector-contract` worktree three commits ahead, and the absence
+  of any PR for the branch. Measured the actual option A blast radius (three
+  files reference `Table`; seven `dataAttributes` occurrences), which is far
+  smaller than the checkpoint recorded.
+- 2026-08-02: user ruled option A. Table's row prop becomes `rows` and its
+  selector prop becomes `data`; W1 executes in the main session rather than via
+  a Kimi round-trip, with the mandatory review gates unchanged.
+- 2026-08-02: W1 implemented and verified. `pnpm check` (both projects),
+  `lint`, `format:check`, `build`, and `build:ladle` pass; `tests/smoke` plus
+  `tests/contracts` are 470/470 and `tests/a11y` is 772/772 (766 before, plus
+  the four a11y cases of the extended contract story and the two new selector
+  tests). The emitted `dist/index.d.ts` shows `TableProps` with `rows` and the
+  `data` selector, so the rename reaches consumers.
+- 2026-08-02: follow-up recorded, not fixed in W1. A `WorkflowProgress` step
+  with `completed: true` that is not the active step renders
+  `text-success-foreground` (#fafafa) on `bg-success-background` (#e4f8e7) in
+  the neutral theme — 1.06:1 against a 4.5:1 requirement. This is pre-existing
+  A11Y-22 breakage, waived only for `workflow--*` story ids, so it surfaced as
+  soon as the state appeared on a `public-contracts--` story. The contract
+  fixture therefore covers plain, tooltip, disabled, and in-progress steps but
+  not the completed state. Fix belongs to theme conformance; the waiver was
+  deliberately not widened, since that would blunt the ratchet.

--- a/project/2026-08-02-v5-post-a3-next-roadmap.md
+++ b/project/2026-08-02-v5-post-a3-next-roadmap.md
@@ -360,3 +360,16 @@ review. Publication and PR readiness remain orchestrator/user decisions.
   fixture therefore covers plain, tooltip, disabled, and in-progress steps but
   not the completed state. Fix belongs to theme conformance; the waiver was
   deliberately not widened, since that would blunt the ratchet.
+- 2026-08-02: recorded for W2 under this plan's stop condition on stale MDX
+  examples — not swept into W1. Eight shipped story docs still show a
+  `data-testid` selector form that no prop actually accepts, all pre-existing
+  at base `77db8822`: `Tabs.stories.mdx:275/282/289` (`:275` also uses the
+  wrong `data-cy` key form), `Navigation.stories.mdx:313`,
+  `Slider.stories.mdx:256`, `Tooltip.stories.mdx:238`,
+  `DatePicker.stories.mdx:145` and `:204`, `DatetimePicker.stories.mdx:213`,
+  `Header.stories.mdx:86`, and `NotificationBadgeWrapper.stories.mdx:251`.
+  They are prose and comment blocks, so nothing type-checks them. W2's
+  inventory must treat them as defects to correct, not as a convention to
+  preserve. `MIGRATION.md` was narrowed to claim only that no selector *prop*
+  accepts `data-testid`, so the guide no longer contradicts docs this release
+  still ships.

--- a/project/2026-08-02-v5-post-a3-next-roadmap.md
+++ b/project/2026-08-02-v5-post-a3-next-roadmap.md
@@ -343,10 +343,14 @@ review. Publication and PR readiness remain orchestrator/user decisions.
   a Kimi round-trip, with the mandatory review gates unchanged.
 - 2026-08-02: W1 implemented and verified. `pnpm check` (both projects),
   `lint`, `format:check`, `build`, and `build:ladle` pass; `tests/smoke` plus
-  `tests/contracts` are 470/470 and `tests/a11y` is 772/772 (766 before, plus
-  the four a11y cases of the extended contract story and the two new selector
-  tests). The emitted `dist/index.d.ts` shows `TableProps` with `rows` and the
-  `data` selector, so the rename reaches consumers.
+  `tests/contracts` are 470/470, which includes the two new selector tests, and
+  `tests/a11y` is 772/772. The a11y total is unchanged by this slice: that
+  suite is a function of the story-id set, and extending the existing
+  `public-contracts--default` story widens what its two existing a11y cases
+  scan without adding a story. The earlier 766 figure predates the merged
+  A1–A3 contract work, not this change. The emitted `dist/index.d.ts` shows
+  `TableProps` with `rows` and the `data` selector, so the rename reaches
+  consumers.
 - 2026-08-02: follow-up recorded, not fixed in W1. A `WorkflowProgress` step
   with `completed: true` that is not the active step renders
   `text-success-foreground` (#fafafa) on `bg-success-background` (#e4f8e7) in

--- a/project/2026-08-02-v5-post-a3-next-roadmap.md
+++ b/project/2026-08-02-v5-post-a3-next-roadmap.md
@@ -3,8 +3,8 @@
 ## Identity and operating contract
 
 - Date: 2026-08-02
-- Status: execution-ready; W1 is the only implementation slice authorised by
-  this handoff.
+- Status: roadmap committed; W1 is prepared but paused at an explicit public
+  API naming gate discovered by the delegated executor and confirmed by Sol.
 - Repository: `uzh-bf/design-system`
 - Release trunk: `v5` (long-lived branch and final merge target).
 - Current base: `origin/v5` at `77db88226e8c2fd14a59ca4e73ae869b5499a43d`, the
@@ -33,6 +33,7 @@ older plans or turn the release trunk into a stack layer.
 | repository visibility | GitHub reports the repository as public; no submodules or project Kimi agent definitions were found | A bounded public-OSS Kimi implementation is eligible. |
 | Kimi runtime | `kimi` 0.31.1 is installed and the `kimi-executor` role/model routing smoke-tested successfully | Kimi may edit only the named W1 scope; it has no push, merge, release, or publication authority. |
 | local worktree | The root checkout is stale and has unrelated `.pnpm-store/` plus an untracked prior roadmap | Keep root untouched. Use the clean `trees/rs-v5-test-selector-contract` worktree. |
+| CI contract coverage | CI runs `tests/smoke` and `tests/a11y`; files under `tests/contracts` are useful local fixtures but are not enforced by the current CI jobs | Put the W1 runtime selector proof under `tests/smoke`; keep type fixtures under the existing contract-type setup. |
 
 ## Non-negotiable boundaries
 
@@ -41,9 +42,10 @@ older plans or turn the release trunk into a stack layer.
 2. W1 is a selector-contract change, not a general test migration. Do not add
    refs, theme changes, visual redesigns, bundle changes, Formik work, export
    changes, new dependencies, or unrelated cleanup.
-3. The supported value shape is exactly `{ cy?: string; test?: string }`,
-   rendered as `data-cy` and `data-test`. Do not introduce or preserve a new
-   `data-testid` convention in W1.
+3. The supported selector value shape is exactly `{ cy?: string; test?:
+   string }`, rendered as `data-cy` and `data-test`. Do not introduce or
+   preserve a new `data-testid` convention in W1. The Table prop name remains
+   gated below because Table already uses `data` for its row collection.
 4. Preserve semantic names for independently addressable controls only when
    each value uses the same shape. Do not collapse a multi-control API into a
    single ambiguous selector.
@@ -115,10 +117,21 @@ data?: {
 }
 ```
 
-- `Table`: replace `dataAttributes` with `data`, document the breaking rename,
-  and keep the attributes on the component's existing outer root. This root is
-  the stable table selector; sortable header buttons remain discoverable by
-  role and are not silently given a second ad-hoc selector API.
+- `Table`: its current public props are `data: RowType[]` (rows) and
+  `dataAttributes: { cy?: string; test?: string }` (selector). A literal
+  `dataAttributes` → `data` rename cannot compile while the row prop remains
+  named `data`. This is a decision gate, not an executor guess:
+
+  | Option | Result | Recommendation |
+  | --- | --- | --- |
+  | A — rename rows to `rows` and selectors to `data` together | One coherent selector vocabulary, but a second breaking Table API rename; requires every in-repository Table call site and migration example to change | Recommended only if the user explicitly accepts the wider v5 break |
+  | B — keep Table's `dataAttributes` for now and implement Workflow's item-level `data` | Smallest safe PR, but the public selector vocabulary remains inconsistent and Table becomes a follow-up | Safe fallback if the wider Table break is not approved |
+  | C — use another selector name on Table | Avoids the collision but creates a third public convention | Reject |
+
+  Do not implement A or silently choose B until the ruling is recorded. Under
+  option A, keep selector attributes on the existing outer root; this root is
+  the stable table selector and sortable header buttons remain discoverable by
+  role rather than receiving an ad-hoc second selector API.
 - `Workflow`: each step is an independently actionable button. Add the same
   optional `data` value to the step item shape and render its `data-cy` and
   `data-test` on that step's actual `<button>` in both tooltip and non-tooltip
@@ -142,8 +155,10 @@ needed by the repository's existing contract-test convention):
 - `packages/design-system/src/PublicContracts.stories.mdx` for the focused
   Ladle fixture (extend the existing contract story; do not create a second
   generic test page)
-- `packages/design-system/tests/contracts/test-selectors.spec.ts`
+- `packages/design-system/tests/smoke/test-selectors.spec.ts`
 - `packages/design-system/tests/contracts/test-selectors.types.ts`
+- `packages/design-system/tests/contracts/composite-refs.types.ts` only if
+  option A requires updating existing Table call-site type fixtures
 - `packages/design-system/tsconfig.types.json` only if the type fixture needs
   an existing project include adjustment
 - `packages/design-system/MIGRATION.md` for the `dataAttributes` → `data`
@@ -154,16 +169,18 @@ Formik modules, or the broader selector inventory in W1.
 
 #### Required W1 proof
 
-1. The existing `PublicContracts.stories.mdx` contract story renders a Table
-   with `data={{ cy: ..., test: ... }}` and a Workflow/WorkflowProgress with
-   distinct per-step selectors.
+1. After the Table gate is resolved, the existing `PublicContracts.stories.mdx`
+   contract story renders the approved Table shape and a
+   Workflow/WorkflowProgress with distinct per-step selectors.
 2. The focused Playwright test asserts the attributes on the Table root and on
    the actual Workflow step buttons, including the tooltip branch. It must also
    assert that a disabled step remains the selector-bearing button rather than
    a wrapper.
 3. A type fixture accepts the exact `cy`/`test` shape and rejects arbitrary
-   keys (especially `data-testid`) and the removed Table `dataAttributes` prop
-   with `@ts-expect-error` where the repository's type-test setup supports it.
+   keys (especially `data-testid`). If option A is approved, it also rejects
+   the removed Table `dataAttributes` prop and row arrays passed through
+   `Table.data`; if option B is chosen, the Table assertion remains a tracked
+   follow-up instead of being faked.
 4. Existing keyboard and accessibility behavior remains intact: Workflow
    buttons remain focusable, disabled steps retain `aria-disabled`, and Table
    sorting/`aria-sort` behavior is unchanged.
@@ -211,19 +228,33 @@ alpha publication is held.
 
 ### W5 — deterministic visual evidence (future)
 
-Follow the existing Ladle/Playwright plan: pinned container, self-hosted fonts,
-reduced motion, one Button canary, then the curated 15-component neutral/UZH
-set, initially report-only in CI. Host-generated screenshots are not baselines.
+Split the visual work into three independently reviewable layers:
+
+- D1: pinned container, self-hosted fonts, reduced motion, one Button canary,
+  and two repeated zero-diff runs. Host-generated screenshots are not
+  baselines.
+- D2: curated 15-component neutral/UZH desktop set, manually inspected and
+  generated in the same container.
+- D3: the identical container in CI with actual/diff artifacts, initially
+  report-only until stability evidence supports a later blocking decision.
 
 ### W6 — release and consumer gates (future and separately authorised)
 
-Only after the engineering work is merged and reviewed:
+Keep the later sequence explicit:
 
-- request explicit alpha authorization;
-- publish through the guarded release path and verify package resolution;
-- run consumer pilots in the consumer repositories;
-- implement the D8 supported override profile only if the pilot requires it;
-- make a fresh, evidence-backed GA decision.
+- E1: request explicit alpha authorization, then publish and verify package
+  resolution;
+- E2: run the GBL preview pilot in its own repository, including React dedupe
+  and `transpilePackages` evidence;
+- E3: implement the already-approved D8 supported primary-ramp override
+  contract;
+- E4: document that profile, migration corrections, and a Klicker acceptance
+  fixture;
+- E5: publish a newer alpha containing E3/E4; the earlier alpha cannot prove
+  later brand-profile code;
+- E6: run the Klicker migration pilot against that newer alpha;
+- E7: re-run final package, consumer, maintainability, and bounded security
+  gates, then request separate `v5.0.0`/`latest` authority.
 
 No item in W6 is authorized by this roadmap.
 
@@ -296,3 +327,8 @@ review. Publication and PR readiness remain orchestrator/user decisions.
 - 2026-08-02: selected W1/B1 as the next bounded execution slice: Table's
   `dataAttributes` rename and Workflow's per-step selector contract, with W2
   inventory rollout held behind the W1 acceptance gate.
+- 2026-08-02: Sol's independent roadmap review found that the planned Table
+  rename collides with its existing required `data: RowType[]` row prop and
+  that `tests/contracts` is not CI-enforced. Kimi was stopped before editing;
+  W1 now awaits the explicit Table naming ruling and will place runtime proof
+  under `tests/smoke`.

--- a/project/2026-08-02-v5-post-a3-next-roadmap.md
+++ b/project/2026-08-02-v5-post-a3-next-roadmap.md
@@ -1,0 +1,294 @@
+# Roadmap — v5 post-A3 release-readiness work
+
+## Identity and operating contract
+
+- Date: 2026-08-02
+- Status: execution-ready; W1 is the only implementation slice authorised by
+  this handoff.
+- Repository: `uzh-bf/design-system`
+- Release trunk: `v5` (long-lived branch and final merge target).
+- Current base: `origin/v5` at `77db88226e8c2fd14a59ca4e73ae869b5499a43d`, the
+  squash merge of PR #189 (A3 composite refs).
+- Working branch: `rs/v5-test-selector-contract`
+- Working directory: `trees/rs-v5-test-selector-contract`
+- Audience: a fresh executor (Kimi) must be able to implement W1 from this
+  file without relying on chat history. The orchestrator owns integration,
+  review, verification, publication, and landing.
+- Predecessors: `project/2026-07-18-v5-production-readiness-roadmap.md`, the
+  2026-08-01 release-readiness stack roadmap, and the merged A1/A2/A3 plan
+  files. The A3 source plan is `project/2026-08-02-v5-composite-refs-plan.md`.
+
+This roadmap is a new post-A3 execution artifact. It does not rewrite the
+older plans or turn the release trunk into a stack layer.
+
+## Current state, verified before implementation
+
+| Surface | Verified state | Consequence |
+| --- | --- | --- |
+| v5 | `origin/v5` is `77db8822` and contains the merged A1/A2/A3 public-contract work | All new branches start from this exact ref. |
+| A3 | PR #189 is merged into v5; its source branch was auto-deleted | Do not reuse or recreate the old A3 PR. |
+| main | `origin/main` remains separate | Never merge v5 into main and never target main from this roadmap. |
+| v5 PR queue | No open PR currently targets v5 | W1 can be a standalone draft PR; W2 may later depend on it. |
+| stack tooling | GitHub native stack capability is available, but no current branch is in a live stack | Do not invent stack metadata. Use a normal standalone W1 PR unless a later approved topology requires a native child. |
+| repository visibility | GitHub reports the repository as public; no submodules or project Kimi agent definitions were found | A bounded public-OSS Kimi implementation is eligible. |
+| Kimi runtime | `kimi` 0.31.1 is installed and the `kimi-executor` role/model routing smoke-tested successfully | Kimi may edit only the named W1 scope; it has no push, merge, release, or publication authority. |
+| local worktree | The root checkout is stale and has unrelated `.pnpm-store/` plus an untracked prior roadmap | Keep root untouched. Use the clean `trees/rs-v5-test-selector-contract` worktree. |
+
+## Non-negotiable boundaries
+
+1. `v5` is the only target branch. There must be no merge, rebase, PR, or
+   promotion from v5 into `main` or another release line.
+2. W1 is a selector-contract change, not a general test migration. Do not add
+   refs, theme changes, visual redesigns, bundle changes, Formik work, export
+   changes, new dependencies, or unrelated cleanup.
+3. The supported value shape is exactly `{ cy?: string; test?: string }`,
+   rendered as `data-cy` and `data-test`. Do not introduce or preserve a new
+   `data-testid` convention in W1.
+4. Preserve semantic names for independently addressable controls only when
+   each value uses the same shape. Do not collapse a multi-control API into a
+   single ambiguous selector.
+5. Do not publish an alpha, create a tag, start a consumer pilot, or claim GA
+   readiness. Those are separate approval gates after the engineering stacks.
+6. Kimi must not push, create/update a PR, mark a PR ready, merge, delete
+   branches/worktrees, deploy, or access secrets. It may edit and locally test
+   only the bounded W1 files below.
+7. Any scope ambiguity, source drift, failed contract, or required API change
+   outside W1 is a stop-and-report condition, not an invitation to widen the
+   slice.
+
+## Target topology
+
+The next work is Stack B from the release-readiness sequence. It is deliberately
+split so the public contract is proven before a broad retrofit:
+
+```mermaid
+flowchart TD
+  V2["v5 at 77db8822<br/>A1 + A2 + A3 merged"]
+  B1["W1 / B1<br/>Table + Workflow selector contract"]
+  B2["W2 / B2<br/>inventory-backed rollout"]
+  V3["v5 after selector stack"]
+  C1["W3 / C1<br/>measure and fix bundle boundaries"]
+  C2["W4 / C2<br/>enforce measured size budget"]
+  D1["W5 / D1-D3<br/>deterministic curated VRT"]
+  R["Explicit alpha authorization"]
+  P["Consumer pilots, brand profile, GA decision"]
+
+  V2 --> B1 --> B2 --> V3 --> C1 --> C2 --> D1 --> R --> P
+```
+
+W1 is one cohesive normal PR rooted at v5. It is not a child of an old A3
+branch, and v5 itself is never a PR or stack layer. W2 is blocked until W1 is
+merged and its public value shape is accepted. If native stack metadata is used
+for W2 later, initialize it explicitly with base `v5`; never rely on the CLI's
+local default (which can resolve to `main`).
+
+## Detailed work packages
+
+### W0 — freshness and plan commit (this branch)
+
+Purpose: make the exact implementation contract travel with the code.
+
+Actions:
+
+- Keep this plan as the first commit on `rs/v5-test-selector-contract`.
+- Before Kimi starts, re-check `git rev-parse HEAD`, `git rev-parse
+  origin/v5`, branch/worktree ownership, and the absence of open competing PRs.
+- Run a staged data-hygiene review before committing the plan. The plan must
+  contain no credentials, tokens, private URLs, customer data, or raw exports.
+
+Ready when: the plan is committed on the clean v5-based branch and the branch
+still points at `77db8822` before implementation edits begin.
+
+### W1 — selector contract proof (current execution slice)
+
+Purpose: prove the public shape on the two highest-value acceptance components
+before inventory-driven rollout.
+
+#### Public contract
+
+Use the existing inline shape rather than adding a shared abstraction:
+
+```ts
+data?: {
+  cy?: string
+  test?: string
+}
+```
+
+- `Table`: replace `dataAttributes` with `data`, document the breaking rename,
+  and keep the attributes on the component's existing outer root. This root is
+  the stable table selector; sortable header buttons remain discoverable by
+  role and are not silently given a second ad-hoc selector API.
+- `Workflow`: each step is an independently actionable button. Add the same
+  optional `data` value to the step item shape and render its `data-cy` and
+  `data-test` on that step's actual `<button>` in both tooltip and non-tooltip
+  paths. Do not put a step selector on the decorative `<li>` or Tooltip wrapper,
+  and do not add a misleading single selector to the `<ol>` root.
+- Keep the `data` value optional and preserve the existing item object passed
+  to `onClick`. Both `Workflow` and `WorkflowProgress` must support the same
+  item-level selector contract.
+- Do not add `data-testid`, spread arbitrary records, or change unrelated
+  attribute forwarding.
+
+#### Owned files for Kimi
+
+Kimi may edit only these paths (plus the new focused test/fixture files if
+needed by the repository's existing contract-test convention):
+
+- `packages/design-system/src/Table.tsx`
+- `packages/design-system/src/Table.stories.mdx`
+- `packages/design-system/src/Workflow.tsx`
+- `packages/design-system/src/Workflow.stories.mdx`
+- `packages/design-system/tests/contracts/test-selectors.spec.ts`
+- `packages/design-system/tests/contracts/test-selectors.types.ts`
+- `packages/design-system/tsconfig.types.json` only if the type fixture needs
+  an existing project include adjustment
+- `packages/design-system/MIGRATION.md` for the `dataAttributes` → `data`
+  migration entry
+
+Do not edit the plan, package metadata, CI, unrelated stories, deprecated
+Formik modules, or the broader selector inventory in W1.
+
+#### Required W1 proof
+
+1. A browser contract story renders a Table with `data={{ cy: ..., test: ...
+   }}` and a Workflow/WorkflowProgress with distinct per-step selectors.
+2. The focused Playwright test asserts the attributes on the Table root and on
+   the actual Workflow step buttons, including the tooltip branch. It must also
+   assert that a disabled step remains the selector-bearing button rather than
+   a wrapper.
+3. A type fixture accepts the exact `cy`/`test` shape and rejects arbitrary
+   keys (especially `data-testid`) and the removed Table `dataAttributes` prop
+   with `@ts-expect-error` where the repository's type-test setup supports it.
+4. Existing keyboard and accessibility behavior remains intact: Workflow
+   buttons remain focusable, disabled steps retain `aria-disabled`, and Table
+   sorting/`aria-sort` behavior is unchanged.
+5. Story prose and migration prose use the new shape and contain no stale
+   `dataAttributes` instructions for Table.
+
+#### W1 acceptance gate
+
+W1 is ready for orchestrator review only when the diff is limited to the owned
+   paths, the attributes are attached to the intended DOM controls, all focused
+   checks pass, and no `data-testid` or arbitrary-record escape hatch was added.
+   A change that requires touching more components is W2, not a W1 extension.
+
+### W2 — inventory-backed selector rollout (future, gated on W1)
+
+Build a current inventory from source, stories, and public examples. Classify
+each interactive component as primary-only, multiple-control, or intentionally
+non-interactive. Retrofit only the approved public set:
+
+- migrate remaining `dataAttributes`, `dataX`, and `Record<string, string>`
+  forms to the same `{ cy, test }` value shape;
+- retain named sub-element props for Modal, picker popovers, and similar
+  multi-control components only when their values use that shape;
+- update stories and `MIGRATION.md` with before/after examples;
+- add inventory-backed DOM contracts, not a global search-and-replace;
+- leave deprecated Formik components, passive layout components, and unrelated
+  consumer examples out unless a separately approved package policy changes.
+
+W2 cannot start until W1's location and naming contract is reviewed and merged.
+
+### W3 — measured bundle boundaries (future)
+
+Capture a reproducible baseline for package build output, compressed sizes,
+large-chunk dependency membership, tarball contents, and peer-runtime markers.
+Then make the smallest measured Vite graph change so generic imports do not
+pull heavy date/chart/carousel dependencies. Preserve root, primitives, CSS,
+and preflight exports. Do not set thresholds before recording the baseline.
+
+### W4 — enforce the bundle budget (future)
+
+Use the installed size-limit tooling only after W3 has measured a useful
+boundary. Add the smallest CI gate that protects that boundary and the publish
+job's existing lint/format/build prerequisites. This remains blocked while
+alpha publication is held.
+
+### W5 — deterministic visual evidence (future)
+
+Follow the existing Ladle/Playwright plan: pinned container, self-hosted fonts,
+reduced motion, one Button canary, then the curated 15-component neutral/UZH
+set, initially report-only in CI. Host-generated screenshots are not baselines.
+
+### W6 — release and consumer gates (future and separately authorised)
+
+Only after the engineering work is merged and reviewed:
+
+- request explicit alpha authorization;
+- publish through the guarded release path and verify package resolution;
+- run consumer pilots in the consumer repositories;
+- implement the D8 supported override profile only if the pilot requires it;
+- make a fresh, evidence-backed GA decision.
+
+No item in W6 is authorized by this roadmap.
+
+## Verification matrix
+
+The orchestrator, not Kimi's report, is the source of truth for completion.
+
+### Kimi's bounded local checks
+
+- changed-file Prettier check;
+- changed-file ESLint with zero warnings;
+- the new focused selector Playwright contract (using the existing Ladle
+  harness and `PWTEST_SKIP_BUILD=1` only when a fresh local build is already
+  verified);
+- the focused type fixture through the repository's existing type-check
+  script, if it is wired by the current package configuration.
+
+### Orchestrator checks before accepting the diff
+
+- inspect `git status`, `git diff --stat`, and the full diff against
+  `77db8822`; reject unrelated files or generated artifacts;
+- `pnpm --dir packages/design-system check`;
+- package type declarations (`tsc -p tsconfig.types.json --noEmit` or the
+  repository-native equivalent);
+- package build and Ladle build;
+- focused selector contract plus existing Table keyboard and Workflow keyboard
+  contracts;
+- full `pnpm --dir packages/design-system test:a11y`;
+- package smoke/consumer import checks if any public export or generated type
+  changes unexpectedly;
+- `git diff --cached` data-hygiene review before committing.
+
+If pnpm's local signature wrapper fails, record the exact error and use the
+repository's installed package-manager binary or CI-equivalent command. Do not
+upgrade dependencies or work around the failure with a new tool.
+
+### Review gates
+
+After the implementation is committed, obtain an exact-range trusted code
+review and simplification pass. At final close-out, run the mandatory
+thermo-nuclear maintainability review and bounded code-level security review.
+Kimi's output is advisory implementation work and can never be the sole final
+review. Publication and PR readiness remain orchestrator/user decisions.
+
+## Stop conditions and traps
+
+- `origin/v5` moves before W1 begins: stop, refresh the branch, and update this
+  plan's base rather than silently rebasing.
+- The local root has unrelated changes: never stage or clean them.
+- A selector lands on an `<li>`, Tooltip wrapper, decorative root, or other
+  non-interactive element: reject and ask for correction.
+- A component needs arbitrary prop spreading, `data-testid`, visual changes,
+  or broad inventory edits to finish: stop at W1 and record the follow-up.
+- A test passes because the story failed open, did not mount, or queried an
+  empty fallback: inspect the producing Ladle run and counters before calling
+  it evidence.
+- Existing MDX examples contain stale conventions outside the owned files:
+  record them for W2; do not sweep them into W1.
+- Any request to push, open/ready a PR, merge, tag, publish, or clean a
+  worktree requires explicit authority outside Kimi's execution brief.
+
+## Progress (append-only)
+
+- 2026-08-02: re-verified `origin/v5` at `77db8822` after PR #189 merged; v5
+  remains the sole release trunk and main remains untouched.
+- 2026-08-02: confirmed the repository is public, has no submodules or local
+  Kimi agent overrides, and the Kimi executor routing smoke test succeeded.
+- 2026-08-02: created isolated worktree `trees/rs-v5-test-selector-contract`
+  from `origin/v5`; root worktree changes were left untouched.
+- 2026-08-02: selected W1/B1 as the next bounded execution slice: Table's
+  `dataAttributes` rename and Workflow's per-step selector contract, with W2
+  inventory rollout held behind the W1 acceptance gate.

--- a/project/2026-08-02-v5-post-a3-next-roadmap.md
+++ b/project/2026-08-02-v5-post-a3-next-roadmap.md
@@ -139,6 +139,9 @@ needed by the repository's existing contract-test convention):
 - `packages/design-system/src/Table.stories.mdx`
 - `packages/design-system/src/Workflow.tsx`
 - `packages/design-system/src/Workflow.stories.mdx`
+- `packages/design-system/src/PublicContracts.stories.mdx` for the focused
+  Ladle fixture (extend the existing contract story; do not create a second
+  generic test page)
 - `packages/design-system/tests/contracts/test-selectors.spec.ts`
 - `packages/design-system/tests/contracts/test-selectors.types.ts`
 - `packages/design-system/tsconfig.types.json` only if the type fixture needs
@@ -151,8 +154,9 @@ Formik modules, or the broader selector inventory in W1.
 
 #### Required W1 proof
 
-1. A browser contract story renders a Table with `data={{ cy: ..., test: ...
-   }}` and a Workflow/WorkflowProgress with distinct per-step selectors.
+1. The existing `PublicContracts.stories.mdx` contract story renders a Table
+   with `data={{ cy: ..., test: ... }}` and a Workflow/WorkflowProgress with
+   distinct per-step selectors.
 2. The focused Playwright test asserts the attributes on the Table root and on
    the actual Workflow step buttons, including the tooltip branch. It must also
    assert that a disabled step remains the selector-bearing button rather than


### PR DESCRIPTION
## What This Adds

This is Stack B layer W1 for the `v5` release branch, the first half of the
test-selector work A1 through A3 left open. It settles the public selector
contract on the two composites that still deviated from it, so the rollout in
W2 has a fixed target to migrate toward.

- `Table` adopts the v5 `data={{ cy, test }}` convention. Its old
  `dataAttributes` prop is gone, and freeing the `data` name moves the row
  collection to `rows`.
- `Workflow` and `WorkflowProgress` steps gain an optional per-step `data`
  selector, rendered on each step's own `<button>`.
- Adds a CI-enforced Playwright proof under `tests/smoke` and a type fixture
  wired into `tsconfig.types.json`.
- Documents both renames in `MIGRATION.md`, including what the v5 selector
  contract does and does not unify.
- Adds the post-A3 roadmap that owns the W1 to W6 sequence and its bundle, VRT,
  and release gates.

## How It Works

- The supported selector value shape is exactly `{ cy?: string; test?: string }`,
  rendered as `data-cy` and `data-test`. No prop accepts `data-testid` or an
  arbitrary attribute record.
- `Table`'s attributes stay on the composite's outer root, which is the stable
  table selector. Sortable header buttons are still addressed by role
  (`columnheader` then `button`) rather than through a second selector API.
- `Workflow` steps are independently actionable, so the selector goes on each
  step's button in both the tooltip and the plain path. A disabled step keeps
  it on that same focusable button. The `<ol>` root carries no selector,
  because no single one would identify a step.
- Runtime proof lives in `tests/smoke/test-selectors.spec.ts`, which CI runs.
  `tests/contracts/test-selectors.types.ts` is a compile-time fixture enforced
  by its entry in `tsconfig.types.json`; the `tests/contracts` directory itself
  is not a CI job.

## Important Details

This is a breaking change, and deliberately not a gradual one. Both halves of
the `Table` rename land in the same commit, so a partially migrated call site
fails to compile instead of silently passing rows through the selector prop:

```tsx
// before
<Table data={rows} dataAttributes={{ cy: 'results', test: 'results' }} />
// after
<Table rows={rows} data={{ cy: 'results', test: 'results' }} />
```

What v5 unifies is the selector value shape, not the number of props.
Composites with several independently addressable controls keep named
per-element props alongside or instead of `data`. Eight components do so after
this change: `Calendar`, `ColorPicker`, `DatePicker`, `DateRangePicker`,
`DatetimePicker`, `Modal`, `Slider`, and `Tooltip`. Every one of their props
already carries the same `{ cy?: string; test?: string }` shape, so W2's
remaining work there is consolidation and docs, not a type migration. Most
components expose no selector prop at all.

The step object passed to `Workflow`'s `onClick` is unchanged.

This branch targets `v5` only. It does not target or merge into `main`, and it
publishes no package, tag, or release.

## Branch Coverage

- Base: `v5` at `77db88226e8c2fd14a59ca4e73ae869b5499a43d`
- Head: `4555b5b7fdf0c987ca6ba0e82ab7fd3b547aeff8`
- Reviewed: 6 commits, 11 files changed, 702 additions and 35 deletions.
- Plan: [`project/2026-08-02-v5-post-a3-next-roadmap.md`](project/2026-08-02-v5-post-a3-next-roadmap.md)
- Covered:
  - `c483d237`, `869eead9`, `f57d8ac3` are plan metadata: the post-A3 roadmap,
    the contract-fixture refinement, and the record of the `Table` naming gate
    that blocked implementation until it was ruled.
  - `e86a3bc1` is the implementation, migration guide, contract story, smoke
    spec, and type fixture.
  - `77f7abfa` fixes three review findings, all in the proof and the prose: a
    type assertion a missing-prop error could have satisfied, a
    `getByRole('list').first()` locator that could silently retarget, and a
    `MIGRATION.md` overclaim about one selector prop per composite.
  - `4555b5b7` narrows the `MIGRATION.md` `data-testid` claim to what is true
    of the prop types, and records the stale story docs as W2 scope.

## Review Focus

- Check that the `Table` rename is complete in both directions and that no call
  site is left half-migrated.
- Review the choice to put `Workflow` selectors on the step button rather than
  the `<li>` or the Tooltip wrapper, and the decision to leave the `<ol>` root
  without one.
- Review the negative type cases in `tests/contracts/test-selectors.types.ts`.
  They reject `dataAttributes`, `data-testid`, and rows passed through `data`.
- Confirm the `MIGRATION.md` wording matches what the prop types actually
  enforce, since an earlier draft of it did not.

## Known Gaps, Recorded Not Fixed

Both are pre-existing at base `77db8822` and deliberately outside this slice.

Eight shipped `.stories.mdx` files still show a `data-testid` selector form no
prop accepts, in prose and comment blocks nothing type-checks:
`Tabs.stories.mdx:275/282/289`, `Navigation.stories.mdx:313`,
`Slider.stories.mdx:256`, `Tooltip.stories.mdx:238`,
`DatePicker.stories.mdx:145` and `:204`, `DatetimePicker.stories.mdx:213`,
`Header.stories.mdx:86`, `NotificationBadgeWrapper.stories.mdx:251`. W2's
inventory must correct them. `MIGRATION.md` was narrowed so the guide no longer
contradicts docs this release still ships.

A `WorkflowProgress` step with `completed: true` that is not the active step
renders `text-success-foreground` (#fafafa) on `bg-success-background`
(#e4f8e7) in the neutral theme, a 1.06:1 ratio against a 4.5:1 requirement.
This is pre-existing A11Y-22 breakage, waived only for `workflow--*` story ids,
so the contract fixture covers plain, tooltip, disabled, and in-progress steps
but not the completed one. The fix belongs to theme conformance; widening the
waiver would blunt the ratchet.

## Verification

Current head (`4555b5b7`), all re-run locally against this exact commit:

- `pnpm check` (`tsc --noEmit` and `tsc -p tsconfig.types.json --noEmit`) -> pass
- `pnpm lint` (`eslint --max-warnings 0`) -> pass
- `pnpm format:check` -> pass
- `pnpm build` -> pass. The emitted `dist/index.d.ts` declares `TableProps` with
  `rows: RowType[]` and the `data?: { cy?, test? }` selector, so the rename
  reaches consumers.
- `tests/smoke` plus `tests/contracts` -> 470/470 pass, including the two new
  selector tests.
- `tests/a11y` -> 772/772 pass across the neutral and UZH themes.

Earlier branch verification:

- `pnpm build:ladle` -> pass, and still current, since no story changed after it.
- Trusted slice review of `e86a3bc1` -> 4 low findings, all fixed in `77f7abfa`
  and re-verified closed by mutation.
- Re-review of `77f7abfa` -> those 4 closed, 1 new low finding, fixed in
  `4555b5b7`.
- Maintainability review over `f57d8ac3..4555b5b7` -> approve, zero findings.
- Bounded security review -> no high-confidence vulnerabilities, risk Low.

On the a11y count: 772 is a function of the story-id set, and this slice adds
no story. It extends the existing `public-contracts--default` one, which widens
what that story's two existing a11y cases scan. The 766 figure in older branch
notes predates the merged A1, A2 and A3 work rather than this change.

Not run:

- Visual regression. The VRT gate is a later roadmap item and no baseline
  exists for the contract story yet.

## Security / Privacy

- Review: bounded security review over the branch range.
- Result: no high-confidence vulnerabilities, risk assessed Low. The change
  adds optional string attributes to rendered DOM and renames props.
- Sensitive data: none. No secrets, credentials, or private payloads are
  included.

## Blocking Before Merge

- [x] CI green on this head. All required checks pass on `4555b5b7`:
  [run 30797042032](https://github.com/uzh-bf/design-system/actions/runs/30797042032)
  covers types, lint, formatting, test, build-and-publish, and all four a11y
  shards; [run 30797042026](https://github.com/uzh-bf/design-system/actions/runs/30797042026)
  covers build, with `deploy` skipped as expected on a non-`v5` head. Greptile
  reviewed at 5/5 with no findings. CodeRabbit auto-review is disabled for base
  branches other than the repository default, so it skipped this PR by
  configuration rather than by result.

## Follow-Up After Merge

- [ ] W2, the inventory-backed selector rollout across the remaining
  composites, which the roadmap gates on this PR landing. It must correct the
  eight stale `data-testid` story docs rather than preserve them.
- [ ] Fix the `WorkflowProgress` completed-step contrast under theme
  conformance, then extend the contract fixture to cover that state.
