### PR TITLE
feat(selectors)!: complete the v5 test-selector rollout on the picker composites

### DIFF
--- a/packages/design-system/MIGRATION.md
+++ b/packages/design-system/MIGRATION.md
@@ -324,6 +324,23 @@ pickers. Address the popover contents on those through `dataCalendar` (or the
 `DatetimePicker`'s `dataHours`/`dataMinutes`/`dataSeconds`) instead of by
 descending from the root.
 
+The value shape is now exported as `TestSelectors`, so a suite can name it
+instead of retyping the literal:
+
+```ts
+import type { TestSelectors } from '@uzh-bf/design-system'
+
+const pickerSelectors: TestSelectors = {
+  cy: 'date-picker',
+  test: 'date-picker',
+}
+```
+
+`DatePicker` no longer forwards undeclared props through to its underlying
+calendar. Typed callers are unaffected, because `DatePickerProps` never
+accepted them; a JavaScript caller that relied on the pass-through to set a
+`react-day-picker` option must now use a declared prop instead.
+
 Most components still expose no selector prop at all; those are unchanged, and
 role- or label-based queries remain the way to reach them.
 

--- a/packages/design-system/MIGRATION.md
+++ b/packages/design-system/MIGRATION.md
@@ -285,16 +285,30 @@ prop and `onChange` callback instead.
 
 v5 standardises the **shape** of every test selector: `{ cy?: string; test?:
 string }`, rendered as `data-cy` and `data-test`. No selector prop accepts
-`data-testid` or an arbitrary attribute record. Some component stories still
-show a `data-testid` form in their examples; those docs are stale and are being
-corrected — the prop types above are authoritative.
+`data-testid` or an arbitrary attribute record. The examples in the component
+stories were corrected to match, except in the deprecated `Formik*` stories,
+which still show the old attribute-record form. The prop types are
+authoritative wherever the two disagree.
 
 Where a composite has one obvious target, the prop is named `data`. Components
-with several independently addressable controls keep their named per-element
-props (`Modal`'s `dataContent`/`dataCloseButton`/`dataPrimaryAction`, the
-pickers' `dataTrigger`/`dataCalendar`/…, `Slider`'s `dataThumb`,
-`Tooltip`'s `dataContent`), which now all carry that same value shape. Many
-composites still expose no selector prop at all; those are unchanged.
+with several independently addressable controls also expose named per-element
+props: `Modal`'s `dataContent`/`dataCloseButton`/`dataPrimaryAction`/
+`dataSecondaryAction`, `Slider`'s `dataThumb`, `Tooltip`'s `dataContent`, and on
+the pickers `dataTrigger`/`dataCalendar` plus the `DatetimePicker`'s
+`dataHours`/`dataMinutes`/`dataSeconds`. Every one carries the same value shape.
+
+`Calendar`, `ColorPicker`, `DatePicker`, `DateRangePicker`, and
+`DatetimePicker` now also accept a root `data` prop, so the component itself is
+addressable alongside its individual controls. This is additive; existing
+per-element props are unchanged. Where both apply to the same element, the
+per-element prop wins. Most components still expose no selector prop at all;
+those are unchanged, and role- or label-based queries remain the way to reach
+them.
+
+`ColorPicker`'s `dataHexInput.test` now renders as `data-test`. It previously
+rendered as a misspelled `data-text`, present since the component shipped, so a
+suite asserting on `[data-text=…]` against the hex input must update that
+selector. The `cy` half was always correct.
 
 `Table` was the last composite still using the old `dataAttributes` name.
 Adopting `data` required freeing that name. **Its row collection moved to

--- a/packages/design-system/MIGRATION.md
+++ b/packages/design-system/MIGRATION.md
@@ -302,16 +302,30 @@ props, among them `Modal`'s `dataContent`/`dataCloseButton`/`dataPrimaryAction`/
 the same value shape.
 
 `Calendar`, `ColorPicker`, `DatePicker`, `DateRangePicker`, and
-`DatetimePicker` now also accept a root `data` prop, so the component itself is
-addressable alongside its individual controls. This is additive; existing
+`DatetimePicker` now also accept a root `data` prop. This is additive; existing
 per-element props are unchanged. The root prop and the per-element props always
 target different elements — the root selector is never inherited by
 sub-elements, so each control still needs its own prop to be addressable.
-`Calendar` additionally accepts raw `data-cy`/`data-test` attributes, which the
-pickers use to forward `dataCalendar`; a raw attribute carrying a value wins
-over `data` on that element. Most components still expose no selector prop at
-all; those are unchanged, and role- or label-based queries remain the way to
-reach them.
+
+Note what the root selector does and does not enclose, because it differs by
+component. On `Calendar` it marks the whole widget, and on `ColorPicker` it
+marks a wrapper that contains the popover. On `DatePicker`, `DateRangePicker`
+and `DatetimePicker` it marks the **trigger area only**: following shadcn's
+composition, `PopoverTrigger` and `PopoverContent` are siblings under
+`Popover` rather than nested inside a shared wrapper, so the open calendar is
+not a descendant of the root selector. A query like
+
+```js
+cy.get('[data-cy="my-picker"]').find('[role="dialog"]')
+```
+
+therefore matches on `ColorPicker` and finds nothing on the three date
+pickers. Address the popover contents on those through `dataCalendar` (or the
+`DatetimePicker`'s `dataHours`/`dataMinutes`/`dataSeconds`) instead of by
+descending from the root.
+
+Most components still expose no selector prop at all; those are unchanged, and
+role- or label-based queries remain the way to reach them.
 
 **`ColorPicker`'s `dataHexInput.test` now renders as `data-test`.** It
 previously rendered as a misspelled `data-text`, present since the component

--- a/packages/design-system/MIGRATION.md
+++ b/packages/design-system/MIGRATION.md
@@ -285,30 +285,45 @@ prop and `onChange` callback instead.
 
 v5 standardises the **shape** of every test selector: `{ cy?: string; test?:
 string }`, rendered as `data-cy` and `data-test`. No selector prop accepts
-`data-testid` or an arbitrary attribute record. The examples in the component
-stories were corrected to match, except in the deprecated `Formik*` stories,
-which still show the old attribute-record form. The prop types are
+`data-testid` or an arbitrary attribute record. The code examples in the
+non-deprecated stories were corrected to match. Two groups still show pre-v5
+forms: the deprecated `Formik*` stories keep the old attribute-record examples,
+and the per-story prop reference lists outside the pickers and `ColorPicker`
+still give the type as `Record<string, string>`. The prop types are
 authoritative wherever the two disagree.
 
 Where a composite has one obvious target, the prop is named `data`. Components
 with several independently addressable controls also expose named per-element
-props: `Modal`'s `dataContent`/`dataCloseButton`/`dataPrimaryAction`/
-`dataSecondaryAction`, `Slider`'s `dataThumb`, `Tooltip`'s `dataContent`, and on
-the pickers `dataTrigger`/`dataCalendar` plus the `DatetimePicker`'s
-`dataHours`/`dataMinutes`/`dataSeconds`. Every one carries the same value shape.
+props, among them `Modal`'s `dataContent`/`dataCloseButton`/`dataPrimaryAction`/
+`dataSecondaryAction`, `Slider`'s `dataThumb`, `Tooltip`'s `dataContent`,
+`ColorPicker`'s `dataHexInput`/`dataSubmit`, and on the pickers
+`dataTrigger`/`dataCalendar`/`dataNextMonth`/`dataPreviousMonth` plus the
+`DatetimePicker`'s `dataHours`/`dataMinutes`/`dataSeconds`. Every one carries
+the same value shape.
 
 `Calendar`, `ColorPicker`, `DatePicker`, `DateRangePicker`, and
 `DatetimePicker` now also accept a root `data` prop, so the component itself is
 addressable alongside its individual controls. This is additive; existing
-per-element props are unchanged. Where both apply to the same element, the
-per-element prop wins. Most components still expose no selector prop at all;
-those are unchanged, and role- or label-based queries remain the way to reach
-them.
+per-element props are unchanged. The root prop and the per-element props always
+target different elements — the root selector is never inherited by
+sub-elements, so each control still needs its own prop to be addressable.
+`Calendar` additionally accepts raw `data-cy`/`data-test` attributes, which the
+pickers use to forward `dataCalendar`; a raw attribute carrying a value wins
+over `data` on that element. Most components still expose no selector prop at
+all; those are unchanged, and role- or label-based queries remain the way to
+reach them.
 
-`ColorPicker`'s `dataHexInput.test` now renders as `data-test`. It previously
-rendered as a misspelled `data-text`, present since the component shipped, so a
-suite asserting on `[data-text=…]` against the hex input must update that
-selector. The `cy` half was always correct.
+**`ColorPicker`'s `dataHexInput.test` now renders as `data-test`.** It
+previously rendered as a misspelled `data-text`, present since the component
+shipped, so a suite asserting against the hex input must update that selector.
+The `cy` half was always correct.
+
+```tsx
+// before
+cy.get('[data-text="hex-input"]')
+// after
+cy.get('[data-test="hex-input"]')
+```
 
 `Table` was the last composite still using the old `dataAttributes` name.
 Adopting `data` required freeing that name. **Its row collection moved to

--- a/packages/design-system/src/Calendar.stories.mdx
+++ b/packages/design-system/src/Calendar.stories.mdx
@@ -37,6 +37,9 @@ Props (Calendar component):
 - className: string - Additional CSS classes
 - showOutsideDays: boolean - Show dates from adjacent months
 - fixedWeeks: boolean - Always show 6 weeks
+- data?: `{ cy?: string; test?: string }` - Test selectors for the calendar root
+- dataNextMonth?: `{ cy?: string; test?: string }` - Test selectors for the next month button
+- dataPreviousMonth?: `{ cy?: string; test?: string }` - Test selectors for the previous month button
 
 Component Structure:
 

--- a/packages/design-system/src/ColorPicker.stories.mdx
+++ b/packages/design-system/src/ColorPicker.stories.mdx
@@ -31,6 +31,7 @@ The props for the ColorPicker component are as follows:
 - @param tooltip - Optional tooltip text or component to display additional information.
 - @param error - An error message to display if the color picker has an error.
 - @param isTouched - Indicates whether the color picker has been touched (used for error display).
+- @param data - Optional data attributes for the component root (for testing purposes).
 - @param dataTrigger - Optional data attributes for the trigger icon (for testing purposes).
 - @param dataHexInput - Optional data attributes for the hex input field (for testing purposes).
 - @param dataSubmit - Optional data attributes for the submit button (for testing purposes).
@@ -76,9 +77,10 @@ Props (ColorPicker component):
 - tooltip?: string | React.ReactNode - Tooltip for the main component
 - error?: string - Error message to display
 - isTouched?: boolean - Whether the field has been touched (for error display)
-- dataTrigger?: Record<string, string> - Data attributes for trigger (testing)
-- dataHexInput?: Record<string, string> - Data attributes for hex input (testing)
-- dataSubmit?: Record<string, string> - Data attributes for submit button (testing)
+- data?: `{ cy?: string; test?: string }` - Test selectors for the component root
+- dataTrigger?: `{ cy?: string; test?: string }` - Test selectors for the trigger
+- dataHexInput?: `{ cy?: string; test?: string }` - Test selectors for the hex input
+- dataSubmit?: `{ cy?: string; test?: string }` - Test selectors for the submit button
 - className?: {
   root?: string,
   trigger?: string,

--- a/packages/design-system/src/ColorPicker.tsx
+++ b/packages/design-system/src/ColorPicker.tsx
@@ -45,6 +45,10 @@ export interface ColorPickerProps {
   colorTooltip?: string
   error?: string
   isTouched?: boolean
+  data?: {
+    cy?: string
+    test?: string
+  }
   dataTrigger?: {
     cy?: string
     test?: string
@@ -89,6 +93,7 @@ const POPOVER_PLACEMENT = {
  * @param tooltip - Optional tooltip text or component to display additional information.
  * @param error - An error message to display if the color picker has an error.
  * @param isTouched - Indicates whether the color picker has been touched (used for error display).
+ * @param data - Optional data attributes for the component root (for testing purposes).
  * @param dataTrigger - Optional data attributes for the trigger icon (for testing purposes).
  * @param dataHexInput - Optional data attributes for the hex input field (for testing purposes).
  * @param dataSubmit - Optional data attributes for the submit button (for testing purposes).
@@ -113,6 +118,7 @@ export function ColorPicker({
   colorTooltip,
   error,
   isTouched,
+  data,
   dataTrigger,
   dataHexInput,
   dataSubmit,
@@ -138,6 +144,8 @@ export function ColorPicker({
         labelType === 'small' && 'flex-col',
         className?.root
       )}
+      data-cy={data?.cy}
+      data-test={data?.test}
     >
       {label && (
         <FormLabel
@@ -250,7 +258,7 @@ export function ColorPicker({
                     color={newColor}
                     onChange={setNewColor}
                     data-cy={dataHexInput?.cy}
-                    data-text={dataHexInput?.test}
+                    data-test={dataHexInput?.test}
                   />
                 </div>
                 <Button

--- a/packages/design-system/src/ColorPicker.tsx
+++ b/packages/design-system/src/ColorPicker.tsx
@@ -10,6 +10,7 @@ import FormLabel from './FormLabel'
 import { FieldErrorIndicator } from './forms/FieldErrorIndicator'
 import Label from './forms/Label'
 import { useFieldError } from './forms/useFieldError'
+import { testAttrs, type TestSelectors } from './lib/testSelectors'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 
 export interface ColorPickerClassName {
@@ -45,22 +46,10 @@ export interface ColorPickerProps {
   colorTooltip?: string
   error?: string
   isTouched?: boolean
-  data?: {
-    cy?: string
-    test?: string
-  }
-  dataTrigger?: {
-    cy?: string
-    test?: string
-  }
-  dataHexInput?: {
-    cy?: string
-    test?: string
-  }
-  dataSubmit?: {
-    cy?: string
-    test?: string
-  }
+  data?: TestSelectors
+  dataTrigger?: TestSelectors
+  dataHexInput?: TestSelectors
+  dataSubmit?: TestSelectors
   className?: ColorPickerClassName
 }
 
@@ -144,8 +133,7 @@ export function ColorPicker({
         labelType === 'small' && 'flex-col',
         className?.root
       )}
-      data-cy={data?.cy}
-      data-test={data?.test}
+      {...testAttrs(data)}
     >
       {label && (
         <FormLabel
@@ -257,8 +245,7 @@ export function ColorPicker({
                     )}
                     color={newColor}
                     onChange={setNewColor}
-                    data-cy={dataHexInput?.cy}
-                    data-test={dataHexInput?.test}
+                    {...testAttrs(dataHexInput)}
                   />
                 </div>
                 <Button

--- a/packages/design-system/src/DatePicker.stories.mdx
+++ b/packages/design-system/src/DatePicker.stories.mdx
@@ -32,7 +32,7 @@ The props for the DatePicker component are as follows:
 - @param isTouched - Whether the date changer has been touched
 - @param className - The optional className object allows you to override the default styling.
 - @param onDateChange - The function to be called when the date is changed (state management)
-- @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the component root
+- @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the trigger area. It does not enclose the popover; use dataCalendar to address the open calendar.
 - @param dataTrigger - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the popover trigger
 - @param dataCalendar - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the calendar
 - @param dataNextMonth - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the next month button
@@ -76,7 +76,7 @@ Props (DatePicker component):
 - hideError?: boolean - Whether to hide the error message
 - isTouched?: boolean - Whether the field has been interacted with
 - className?: Record<string, string> - Styling overrides for different parts
-- data?: `{ cy?: string; test?: string }` - Test selectors for the component root
+- data?: `{ cy?: string; test?: string }` - Test selectors for the trigger area (does not enclose the popover)
 - dataTrigger?: `{ cy?: string; test?: string }` - Test selectors for the popover trigger
 - dataCalendar?: `{ cy?: string; test?: string }` - Test selectors for the calendar
 - dataNextMonth?: `{ cy?: string; test?: string }` - Test selectors for the next month button

--- a/packages/design-system/src/DatePicker.stories.mdx
+++ b/packages/design-system/src/DatePicker.stories.mdx
@@ -32,6 +32,7 @@ The props for the DatePicker component are as follows:
 - @param isTouched - Whether the date changer has been touched
 - @param className - The optional className object allows you to override the default styling.
 - @param onDateChange - The function to be called when the date is changed (state management)
+- @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the component root
 - @param dataTrigger - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the popover trigger
 - @param dataCalendar - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the calendar
 - @param dataNextMonth - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the next month button
@@ -75,10 +76,11 @@ Props (DatePicker component):
 - hideError?: boolean - Whether to hide the error message
 - isTouched?: boolean - Whether the field has been interacted with
 - className?: Record<string, string> - Styling overrides for different parts
-- dataTrigger?: Record<string, string> - Data attributes for popover trigger
-- dataCalendar?: Record<string, string> - Data attributes for calendar
-- dataNextMonth?: Record<string, string> - Data attributes for next month button
-- dataPreviousMonth?: Record<string, string> - Data attributes for previous month button
+- data?: `{ cy?: string; test?: string }` - Test selectors for the component root
+- dataTrigger?: `{ cy?: string; test?: string }` - Test selectors for the popover trigger
+- dataCalendar?: `{ cy?: string; test?: string }` - Test selectors for the calendar
+- dataNextMonth?: `{ cy?: string; test?: string }` - Test selectors for the next month button
+- dataPreviousMonth?: `{ cy?: string; test?: string }` - Test selectors for the previous month button
 
 Component Structure:
 

--- a/packages/design-system/src/DatePicker.stories.mdx
+++ b/packages/design-system/src/DatePicker.stories.mdx
@@ -141,10 +141,10 @@ const error = !birthDate && touched ? "Birth date is required" : ""
 <DatePicker
   date={testDate}
   onDateChange={setTestDate}
-  dataTrigger={{ 'data-cy': 'date-trigger' }}
-  dataCalendar={{ 'data-testid': 'calendar' }}
-  dataNextMonth={{ 'data-cy': 'next-month' }}
-  dataPreviousMonth={{ 'data-cy': 'prev-month' }}
+  dataTrigger={{ cy: 'date-trigger' }}
+  dataCalendar={{ test: 'calendar' }}
+  dataNextMonth={{ cy: 'next-month' }}
+  dataPreviousMonth={{ cy: 'prev-month' }}
 />
 
 // Custom styling
@@ -201,7 +201,7 @@ Testing Support:
 
 - Comprehensive data attributes for all interactive elements
 - Separate attributes for trigger, calendar, navigation
-- Support for both data-cy and data-testid patterns
+- Support for the `data` selector prop, rendering `data-cy` and `data-test`
 - Complete E2E testing capability
 
 Accessibility Features:

--- a/packages/design-system/src/DatePicker.tsx
+++ b/packages/design-system/src/DatePicker.tsx
@@ -40,6 +40,10 @@ export interface DatePickerProps {
   hideError?: boolean
   isTouched?: boolean
   className?: DatePickerClassName
+  data?: {
+    cy?: string
+    test?: string
+  }
   dataTrigger?: {
     cy?: string
     test?: string
@@ -77,6 +81,7 @@ export interface DatePickerProps {
  * @param isTouched - Whether the date changer has been touched
  * @param className - The optional className object allows you to override the default styling.
  * @param onDateChange - The function to be called when the date is changed (state management)
+ * @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the component root
  * @param dataTrigger - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the popover trigger
  * @param dataCalendar - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the calendar
  * @param dataNextMonth - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the next month button
@@ -100,6 +105,7 @@ export function DatePicker({
   hideError = false,
   isTouched = false,
   className,
+  data,
   dataTrigger,
   dataCalendar,
   dataNextMonth,
@@ -114,6 +120,8 @@ export function DatePicker({
           labelType === 'small' && 'flex-col',
           className?.trigger
         )}
+        data-cy={data?.cy}
+        data-test={data?.test}
       >
         {label && (
           <FormLabel

--- a/packages/design-system/src/DatePicker.tsx
+++ b/packages/design-system/src/DatePicker.tsx
@@ -67,7 +67,7 @@ export interface DatePickerProps {
  * @param isTouched - Whether the date changer has been touched
  * @param className - The optional className object allows you to override the default styling.
  * @param onDateChange - The function to be called when the date is changed (state management)
- * @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the component root
+ * @param data - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the trigger area. It does not enclose the popover; use dataCalendar to address the open calendar.
  * @param dataTrigger - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the popover trigger
  * @param dataCalendar - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the calendar
  * @param dataNextMonth - The object of data attributes that can be used for testing (e.g. data-test or data-cy) for the next month button

--- a/packages/design-system/src/DatePicker.tsx
+++ b/packages/design-system/src/DatePicker.tsx
@@ -8,6 +8,7 @@ import React, { Dispatch, SetStateAction } from 'react'
 import { DayPicker } from 'react-day-picker'
 import { twMerge } from 'tailwind-merge'
 import FormLabel from './FormLabel'
+import { testAttrs, type TestSelectors } from './lib/testSelectors'
 import Tooltip from './Tooltip'
 import { Button } from './ui/button'
 import { Calendar } from './ui/calendar'
@@ -40,26 +41,11 @@ export interface DatePickerProps {
   hideError?: boolean
   isTouched?: boolean
   className?: DatePickerClassName
-  data?: {
-    cy?: string
-    test?: string
-  }
-  dataTrigger?: {
-    cy?: string
-    test?: string
-  }
-  dataCalendar?: {
-    cy?: string
-    test?: string
-  }
-  dataNextMonth?: {
-    cy?: string
-    test?: string
-  }
-  dataPreviousMonth?: {
-    cy?: string
-    test?: string
-  }
+  data?: TestSelectors
+  dataTrigger?: TestSelectors
+  dataCalendar?: TestSelectors
+  dataNextMonth?: TestSelectors
+  dataPreviousMonth?: TestSelectors
 }
 
 /**
@@ -110,7 +96,6 @@ export function DatePicker({
   dataCalendar,
   dataNextMonth,
   dataPreviousMonth,
-  ...props
 }: DatePickerProps) {
   return (
     <Popover>
@@ -120,8 +105,7 @@ export function DatePicker({
           labelType === 'small' && 'flex-col',
           className?.trigger
         )}
-        data-cy={data?.cy}
-        data-test={data?.test}
+        {...testAttrs(data)}
       >
         {label && (
           <FormLabel
@@ -151,8 +135,7 @@ export function DatePicker({
                   'border-destructive bg-destructive-background',
                 className?.input
               )}
-              data-cy={dataTrigger?.cy}
-              data-test={dataTrigger?.test}
+              {...testAttrs(dataTrigger)}
             >
               <FontAwesomeIcon
                 icon={faCalendar}
@@ -199,11 +182,9 @@ export function DatePicker({
               onDateChange(newDate)
             }
           }}
-          data-cy={dataCalendar?.cy}
-          data-test={dataCalendar?.test}
+          data={dataCalendar}
           dataNextMonth={dataNextMonth}
           dataPreviousMonth={dataPreviousMonth}
-          {...props}
         />
       </PopoverContent>
     </Popover>

--- a/packages/design-system/src/DateRangePicker.stories.mdx
+++ b/packages/design-system/src/DateRangePicker.stories.mdx
@@ -37,7 +37,7 @@ Props (DateRangePicker component):
 - captionLayout: "dropdown" | "label" | ... - Calendar caption layout
 - disabled: boolean - Disables the trigger
 - className: { root?, label?, trigger? } - Style overrides
-- data?: `{ cy?: string; test?: string }` - Test selectors for the component root
+- data?: `{ cy?: string; test?: string }` - Test selectors for the trigger area (does not enclose the popover)
 - dataTrigger?: `{ cy?: string; test?: string }` - Test selectors for the popover trigger
 - dataCalendar?: `{ cy?: string; test?: string }` - Test selectors for the calendar
 - dataNextMonth?: `{ cy?: string; test?: string }` - Test selectors for the next month button

--- a/packages/design-system/src/DateRangePicker.stories.mdx
+++ b/packages/design-system/src/DateRangePicker.stories.mdx
@@ -37,6 +37,11 @@ Props (DateRangePicker component):
 - captionLayout: "dropdown" | "label" | ... - Calendar caption layout
 - disabled: boolean - Disables the trigger
 - className: { root?, label?, trigger? } - Style overrides
+- data?: `{ cy?: string; test?: string }` - Test selectors for the component root
+- dataTrigger?: `{ cy?: string; test?: string }` - Test selectors for the popover trigger
+- dataCalendar?: `{ cy?: string; test?: string }` - Test selectors for the calendar
+- dataNextMonth?: `{ cy?: string; test?: string }` - Test selectors for the next month button
+- dataPreviousMonth?: `{ cy?: string; test?: string }` - Test selectors for the previous month button
 
 Usage Examples:
 

--- a/packages/design-system/src/DateRangePicker.tsx
+++ b/packages/design-system/src/DateRangePicker.tsx
@@ -64,7 +64,7 @@ const DATE_FORMAT = 'DD.MM.YYYY'
  * @param tooltip - Tooltip shown next to the label (only when a label is given).
  * @param disabled - Whether the range picker is disabled.
  * @param className - The optional className object allows you to override the default styling.
- * @param data - Data attributes for the component root (e.g. data-test, data-cy).
+ * @param data - Data attributes for the trigger area (e.g. data-test, data-cy). It does not enclose the popover; use dataCalendar to address the open calendar.
  * @param dataTrigger - Data attributes for the popover trigger (e.g. data-test, data-cy).
  * @param dataCalendar - Data attributes for the calendar.
  * @param dataNextMonth - Data attributes for the next-month button.

--- a/packages/design-system/src/DateRangePicker.tsx
+++ b/packages/design-system/src/DateRangePicker.tsx
@@ -8,6 +8,7 @@ import { DayPicker, type DateRange } from 'react-day-picker'
 import { twMerge } from 'tailwind-merge'
 
 import FormLabel from './FormLabel'
+import { testAttrs, type TestSelectors } from './lib/testSelectors'
 import { Button } from './ui/button'
 import { Calendar } from './ui/calendar'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
@@ -36,26 +37,11 @@ export interface DateRangePickerProps {
   tooltip?: string | React.ReactNode
   disabled?: boolean
   className?: DateRangePickerClassName
-  data?: {
-    cy?: string
-    test?: string
-  }
-  dataTrigger?: {
-    cy?: string
-    test?: string
-  }
-  dataCalendar?: {
-    cy?: string
-    test?: string
-  }
-  dataNextMonth?: {
-    cy?: string
-    test?: string
-  }
-  dataPreviousMonth?: {
-    cy?: string
-    test?: string
-  }
+  data?: TestSelectors
+  dataTrigger?: TestSelectors
+  dataCalendar?: TestSelectors
+  dataNextMonth?: TestSelectors
+  dataPreviousMonth?: TestSelectors
 }
 
 const DATE_FORMAT = 'DD.MM.YYYY'
@@ -119,8 +105,7 @@ export function DateRangePicker({
           labelType === 'small' && 'flex-col',
           className?.root
         )}
-        data-cy={data?.cy}
-        data-test={data?.test}
+        {...testAttrs(data)}
       >
         {label && (
           <FormLabel
@@ -144,8 +129,7 @@ export function DateRangePicker({
               !range?.from && 'text-[#666666]',
               className?.trigger
             )}
-            data-cy={dataTrigger?.cy}
-            data-test={dataTrigger?.test}
+            {...testAttrs(dataTrigger)}
           >
             <FontAwesomeIcon
               icon={faCalendar}
@@ -168,8 +152,7 @@ export function DateRangePicker({
           selected={range}
           defaultMonth={range?.from ?? range?.to}
           onSelect={onRangeChange}
-          data-cy={dataCalendar?.cy}
-          data-test={dataCalendar?.test}
+          data={dataCalendar}
           dataNextMonth={dataNextMonth}
           dataPreviousMonth={dataPreviousMonth}
         />

--- a/packages/design-system/src/DateRangePicker.tsx
+++ b/packages/design-system/src/DateRangePicker.tsx
@@ -36,6 +36,10 @@ export interface DateRangePickerProps {
   tooltip?: string | React.ReactNode
   disabled?: boolean
   className?: DateRangePickerClassName
+  data?: {
+    cy?: string
+    test?: string
+  }
   dataTrigger?: {
     cy?: string
     test?: string
@@ -74,6 +78,7 @@ const DATE_FORMAT = 'DD.MM.YYYY'
  * @param tooltip - Tooltip shown next to the label (only when a label is given).
  * @param disabled - Whether the range picker is disabled.
  * @param className - The optional className object allows you to override the default styling.
+ * @param data - Data attributes for the component root (e.g. data-test, data-cy).
  * @param dataTrigger - Data attributes for the popover trigger (e.g. data-test, data-cy).
  * @param dataCalendar - Data attributes for the calendar.
  * @param dataNextMonth - Data attributes for the next-month button.
@@ -95,6 +100,7 @@ export function DateRangePicker({
   tooltip,
   disabled = false,
   className,
+  data,
   dataTrigger,
   dataCalendar,
   dataNextMonth,
@@ -113,6 +119,8 @@ export function DateRangePicker({
           labelType === 'small' && 'flex-col',
           className?.root
         )}
+        data-cy={data?.cy}
+        data-test={data?.test}
       >
         {label && (
           <FormLabel

--- a/packages/design-system/src/DatetimePicker.stories.mdx
+++ b/packages/design-system/src/DatetimePicker.stories.mdx
@@ -28,6 +28,7 @@ The props for the DatetimePicker component are as follows:
 - @param granularity - The smallest unit displayed by the picker (e.g., 'second', 'minute', 'hour', 'day').
 - @param className - Optional object to override default styling for trigger, input, label, tooltip, and error.
 - @param defaultPopupValue - The default date and time shown when the calendar popup opens.
+- @param data - Data attributes for testing the component root.
 - @param dataTrigger - Data attributes for testing the popover trigger.
 - @param dataCalendar - Data attributes for testing the calendar.
 - @param dataHours - Data attributes for testing the hours input.
@@ -104,13 +105,14 @@ Form Integration Props:
 
 Testing Props:
 
-- dataTrigger?: Record<string, string> - Data attributes for trigger
-- dataCalendar?: Record<string, string> - Data attributes for calendar
-- dataHours?: Record<string, string> - Data attributes for hours input
-- dataMinutes?: Record<string, string> - Data attributes for minutes input
-- dataSeconds?: Record<string, string> - Data attributes for seconds input
-- dataNextMonth?: Record<string, string> - Data attributes for next month
-- dataPreviousMonth?: Record<string, string> - Data attributes for previous month
+- data?: `{ cy?: string; test?: string }` - Test selectors for the component root
+- dataTrigger?: `{ cy?: string; test?: string }` - Test selectors for the trigger
+- dataCalendar?: `{ cy?: string; test?: string }` - Test selectors for the calendar
+- dataHours?: `{ cy?: string; test?: string }` - Test selectors for the hours input
+- dataMinutes?: `{ cy?: string; test?: string }` - Test selectors for the minutes input
+- dataSeconds?: `{ cy?: string; test?: string }` - Test selectors for the seconds input
+- dataNextMonth?: `{ cy?: string; test?: string }` - Test selectors for the next month button
+- dataPreviousMonth?: `{ cy?: string; test?: string }` - Test selectors for the previous month button
 
 Component Structure:
 

--- a/packages/design-system/src/DatetimePicker.stories.mdx
+++ b/packages/design-system/src/DatetimePicker.stories.mdx
@@ -209,10 +209,10 @@ const error = !deadline && touched ? "Deadline is required" : ""
 <DatetimePicker
   value={testDatetime}
   onChange={setTestDatetime}
-  dataTrigger={{ 'data-cy': 'datetime-trigger' }}
-  dataCalendar={{ 'data-testid': 'calendar' }}
-  dataHours={{ 'data-cy': 'hours-input' }}
-  dataMinutes={{ 'data-cy': 'minutes-input' }}
+  dataTrigger={{ cy: 'datetime-trigger' }}
+  dataCalendar={{ test: 'calendar' }}
+  dataHours={{ cy: 'hours-input' }}
+  dataMinutes={{ cy: 'minutes-input' }}
 />
 ```
 

--- a/packages/design-system/src/DatetimePicker.stories.mdx
+++ b/packages/design-system/src/DatetimePicker.stories.mdx
@@ -28,7 +28,7 @@ The props for the DatetimePicker component are as follows:
 - @param granularity - The smallest unit displayed by the picker (e.g., 'second', 'minute', 'hour', 'day').
 - @param className - Optional object to override default styling for trigger, input, label, tooltip, and error.
 - @param defaultPopupValue - The default date and time shown when the calendar popup opens.
-- @param data - Data attributes for testing the component root.
+- @param data - Data attributes for testing the trigger area. It does not enclose the popover; use dataCalendar to address the open calendar.
 - @param dataTrigger - Data attributes for testing the popover trigger.
 - @param dataCalendar - Data attributes for testing the calendar.
 - @param dataHours - Data attributes for testing the hours input.
@@ -105,7 +105,7 @@ Form Integration Props:
 
 Testing Props:
 
-- data?: `{ cy?: string; test?: string }` - Test selectors for the component root
+- data?: `{ cy?: string; test?: string }` - Test selectors for the trigger area (does not enclose the popover)
 - dataTrigger?: `{ cy?: string; test?: string }` - Test selectors for the trigger
 - dataCalendar?: `{ cy?: string; test?: string }` - Test selectors for the calendar
 - dataHours?: `{ cy?: string; test?: string }` - Test selectors for the hours input

--- a/packages/design-system/src/DatetimePicker.tsx
+++ b/packages/design-system/src/DatetimePicker.tsx
@@ -582,6 +582,7 @@ type DateTimePickerProps = {
    * Show the default month and time when popup the calendar. Default is the current Date().
    **/
   defaultPopupValue?: Date
+  data?: { cy?: string; test?: string }
   dataTrigger?: { cy?: string; test?: string }
   dataCalendar?: { cy?: string; test?: string }
   dataHours?: { cy?: string; test?: string }
@@ -623,6 +624,7 @@ type DateTimePickerRef = HTMLButtonElement
  * @param granularity - The smallest unit displayed by the picker (e.g., 'second', 'minute', 'hour', 'day').
  * @param className - Optional object to override default styling for trigger, input, label, tooltip, and error.
  * @param defaultPopupValue - The default date and time shown when the calendar popup opens.
+ * @param data - Data attributes for testing the component root.
  * @param dataTrigger - Data attributes for testing the popover trigger.
  * @param dataCalendar - Data attributes for testing the calendar.
  * @param dataHours - Data attributes for testing the hours input.
@@ -667,6 +669,7 @@ const DateTimePicker = ({
   required = false,
   tooltip,
   ref,
+  data,
   ...props
 }: DateTimePickerProps) => {
   const [month, setMonth] = React.useState<Date>(value ?? defaultPopupValue)
@@ -740,6 +743,8 @@ const DateTimePicker = ({
           labelType === 'small' && 'flex-col',
           className?.trigger
         )}
+        data-cy={data?.cy}
+        data-test={data?.test}
       >
         {label && (
           <FormLabel

--- a/packages/design-system/src/DatetimePicker.tsx
+++ b/packages/design-system/src/DatetimePicker.tsx
@@ -622,7 +622,7 @@ type DateTimePickerRef = HTMLButtonElement
  * @param granularity - The smallest unit displayed by the picker (e.g., 'second', 'minute', 'hour', 'day').
  * @param className - Optional object to override default styling for trigger, input, label, tooltip, and error.
  * @param defaultPopupValue - The default date and time shown when the calendar popup opens.
- * @param data - Data attributes for testing the component root.
+ * @param data - Data attributes for testing the trigger area. It does not enclose the popover; use dataCalendar to address the open calendar.
  * @param dataTrigger - Data attributes for testing the popover trigger.
  * @param dataCalendar - Data attributes for testing the calendar.
  * @param dataHours - Data attributes for testing the hours input.

--- a/packages/design-system/src/DatetimePicker.tsx
+++ b/packages/design-system/src/DatetimePicker.tsx
@@ -12,6 +12,7 @@ import { useImperativeHandle } from 'react'
 import { DayPicker, DayPickerProps } from 'react-day-picker'
 import { twMerge } from 'tailwind-merge'
 import FormLabel from './FormLabel'
+import { testAttrs, type TestSelectors } from './lib/testSelectors'
 import { cn } from './lib/utils'
 import Tooltip from './Tooltip'
 import { Button } from './ui/button'
@@ -427,9 +428,9 @@ interface TimePickerProps {
    * Default is 'second'.
    * */
   granularity?: Granularity
-  dataHours?: { cy?: string; test?: string }
-  dataMinutes?: { cy?: string; test?: string }
-  dataSeconds?: { cy?: string; test?: string }
+  dataHours?: TestSelectors
+  dataMinutes?: TestSelectors
+  dataSeconds?: TestSelectors
 }
 
 interface TimePickerRef {
@@ -485,8 +486,7 @@ const TimePicker = React.forwardRef<TimePickerRef, TimePickerProps>(
           period={period}
           onRightFocus={() => minuteRef?.current?.focus()}
           className="h-8 text-sm"
-          data-cy={dataHours?.cy}
-          data-test={dataHours?.test}
+          {...testAttrs(dataHours)}
         />
         {(granularity === 'minute' || granularity === 'second') && (
           <>
@@ -500,8 +500,7 @@ const TimePicker = React.forwardRef<TimePickerRef, TimePickerProps>(
               onLeftFocus={() => hourRef?.current?.focus()}
               onRightFocus={() => secondRef?.current?.focus()}
               className="h-8 text-sm"
-              data-cy={dataMinutes?.cy}
-              data-test={dataMinutes?.test}
+              {...testAttrs(dataMinutes)}
             />
           </>
         )}
@@ -517,8 +516,7 @@ const TimePicker = React.forwardRef<TimePickerRef, TimePickerProps>(
               onLeftFocus={() => minuteRef?.current?.focus()}
               onRightFocus={() => periodRef?.current?.focus()}
               className="h-8 text-sm"
-              data-cy={dataSeconds?.cy}
-              data-test={dataSeconds?.test}
+              {...testAttrs(dataSeconds)}
             />
           </>
         )}
@@ -582,14 +580,14 @@ type DateTimePickerProps = {
    * Show the default month and time when popup the calendar. Default is the current Date().
    **/
   defaultPopupValue?: Date
-  data?: { cy?: string; test?: string }
-  dataTrigger?: { cy?: string; test?: string }
-  dataCalendar?: { cy?: string; test?: string }
-  dataHours?: { cy?: string; test?: string }
-  dataMinutes?: { cy?: string; test?: string }
-  dataSeconds?: { cy?: string; test?: string }
-  dataNextMonth?: { cy?: string; test?: string }
-  dataPreviousMonth?: { cy?: string; test?: string }
+  data?: TestSelectors
+  dataTrigger?: TestSelectors
+  dataCalendar?: TestSelectors
+  dataHours?: TestSelectors
+  dataMinutes?: TestSelectors
+  dataSeconds?: TestSelectors
+  dataNextMonth?: TestSelectors
+  dataPreviousMonth?: TestSelectors
   error?: string
   hideError?: boolean
   isTouched?: boolean
@@ -743,8 +741,7 @@ const DateTimePicker = ({
           labelType === 'small' && 'flex-col',
           className?.trigger
         )}
-        data-cy={data?.cy}
-        data-test={data?.test}
+        {...testAttrs(data)}
       >
         {label && (
           <FormLabel
@@ -773,8 +770,7 @@ const DateTimePicker = ({
                 className?.input
               )}
               ref={ref}
-              data-cy={props.dataTrigger?.cy}
-              data-test={props.dataTrigger?.test}
+              {...testAttrs(props.dataTrigger)}
             >
               <FontAwesomeIcon
                 icon={faCalendar}
@@ -852,14 +848,15 @@ const DateTimePicker = ({
             locale={locale}
             dataNextMonth={props.dataNextMonth}
             dataPreviousMonth={props.dataPreviousMonth}
-            data-cy={props.dataCalendar?.cy}
-            data-test={props.dataCalendar?.test}
+            data={props.dataCalendar}
             className={
               granularity !== 'day'
                 ? 'rounded-none border-0 shadow-none'
                 : undefined
             }
-            {...props}
+            weekStartsOn={props.weekStartsOn}
+            showWeekNumber={props.showWeekNumber}
+            showOutsideDays={props.showOutsideDays}
           />
           {granularity !== 'day' && (
             <div className="border-t border-[#E0E0E0] bg-white p-3">

--- a/packages/design-system/src/Header.stories.mdx
+++ b/packages/design-system/src/Header.stories.mdx
@@ -83,7 +83,7 @@ Usage Examples:
 // With testing attributes
 <Header.H2
   id="main-section"
-  data={{ 'data-cy': 'section-heading', 'data-testid': 'main-section' }}
+  data={{ cy: 'section-heading', test: 'main-section' }}
 >
   Testable Section Heading
 </Header.H2>

--- a/packages/design-system/src/Navigation.stories.mdx
+++ b/packages/design-system/src/Navigation.stories.mdx
@@ -303,14 +303,14 @@ Usage Examples:
       key: 'test-button',
       label: 'Test Button',
       onClick: handleClick,
-      data: { 'data-cy': 'nav-button' }
+      data: { cy: 'nav-button' }
     },
     {
       type: 'dropdown',
       key: 'test-dropdown',
       label: 'Test Menu',
       elements: testMenuItems,
-      data: { 'data-testid': 'nav-dropdown' }
+      data: { test: 'nav-dropdown' }
     }
   ]}
 />

--- a/packages/design-system/src/NotificationBadgeWrapper.stories.mdx
+++ b/packages/design-system/src/NotificationBadgeWrapper.stories.mdx
@@ -185,7 +185,7 @@ const hasNotifications = unreadCount > 0
 // Testing configuration
 <NotificationBadgeWrapper
   count={testCount}
-  data={{ 'data-cy': 'notification-badge' }}
+  data={{ cy: 'notification-badge' }}
   id="test-notification"
 >
   <TestComponent />
@@ -247,8 +247,7 @@ Accessibility Considerations:
 Testing Support:
 
 - id prop for unique element identification
-- data prop for comprehensive testing attributes
-- Support for both data-cy and data-testid patterns
+- Support for the `data` selector prop, rendering `data-cy` and `data-test`
 - Consistent element targeting for E2E tests
 
 Related Components:

--- a/packages/design-system/src/PublicContracts.stories.mdx
+++ b/packages/design-system/src/PublicContracts.stories.mdx
@@ -1,8 +1,13 @@
 import Button from './Button'
+import ColorPicker from './ColorPicker'
+import DatePicker from './DatePicker'
+import DateRangePicker from './DateRangePicker'
+import { DateTimePicker } from './DatetimePicker'
 import Navigation from './Navigation'
 import Progress from './Progress'
 import Table from './Table'
 import Workflow from './Workflow'
+import { Calendar } from './ui/calendar'
 
 {/* START README */}
 <div className="prose prose-sm max-w-none">
@@ -11,6 +16,10 @@ and Progress with representative native, ARIA, and data attributes. It also
 pins the v5 selector contract: `Table` carries its selectors on the composite
 root through `data`, while `Workflow` and `WorkflowProgress` carry per-step
 selectors on each step's own button, including the tooltip and disabled paths.
+`Calendar`, `ColorPicker`, `DatePicker`, `DateRangePicker` and `DatetimePicker`
+pin the root `data` selector alongside their per-element props, proving the root
+stays addressable while the popover is closed and that a per-element selector
+still wins on the element it names.
 </div>
 {/* END README */}
 
@@ -98,6 +107,49 @@ export const Default = () => (
           },
         },
       ]}
+    />
+    <Calendar
+      mode="single"
+      data={{ cy: 'contract-calendar', test: 'contract-calendar' }}
+    />
+    <ColorPicker
+      color="#aa0000"
+      onSubmit={() => undefined}
+      submitText="Contract submit"
+      colorLabel="Contract colour"
+      triggerAriaLabel="Contract colour picker"
+      data={{ cy: 'contract-colorpicker', test: 'contract-colorpicker' }}
+      dataHexInput={{
+        cy: 'contract-hex-input',
+        test: 'contract-hex-input',
+      }}
+    />
+    <DatePicker
+      label="Contract date"
+      date={undefined}
+      onDateChange={() => undefined}
+      data={{ cy: 'contract-datepicker', test: 'contract-datepicker' }}
+      dataCalendar={{
+        cy: 'contract-datepicker-calendar',
+        test: 'contract-datepicker-calendar',
+      }}
+    />
+    <DateRangePicker
+      label="Contract range"
+      range={undefined}
+      onRangeChange={() => undefined}
+      data={{
+        cy: 'contract-daterangepicker',
+        test: 'contract-daterangepicker',
+      }}
+    />
+    <DateTimePicker
+      label="Contract datetime"
+      onChange={() => undefined}
+      data={{
+        cy: 'contract-datetimepicker',
+        test: 'contract-datetimepicker',
+      }}
     />
   </div>
 )

--- a/packages/design-system/src/PublicContracts.stories.mdx
+++ b/packages/design-system/src/PublicContracts.stories.mdx
@@ -111,6 +111,14 @@ export const Default = () => (
     <Calendar
       mode="single"
       data={{ cy: 'contract-calendar', test: 'contract-calendar' }}
+      dataNextMonth={{
+        cy: 'contract-calendar-next',
+        test: 'contract-calendar-next',
+      }}
+      dataPreviousMonth={{
+        cy: 'contract-calendar-previous',
+        test: 'contract-calendar-previous',
+      }}
     />
     <ColorPicker
       color="#aa0000"
@@ -150,6 +158,10 @@ export const Default = () => (
         cy: 'contract-daterangepicker',
         test: 'contract-daterangepicker',
       }}
+      dataTrigger={{
+        cy: 'contract-daterangepicker-trigger',
+        test: 'contract-daterangepicker-trigger',
+      }}
     />
     <DateTimePicker
       label="Contract datetime"
@@ -162,6 +174,9 @@ export const Default = () => (
         cy: 'contract-datetimepicker-trigger',
         test: 'contract-datetimepicker-trigger',
       }}
+      dataHours={{ cy: 'contract-datetimepicker-hours' }}
+      dataMinutes={{ cy: 'contract-datetimepicker-minutes' }}
+      dataSeconds={{ cy: 'contract-datetimepicker-seconds' }}
     />
   </div>
 )

--- a/packages/design-system/src/PublicContracts.stories.mdx
+++ b/packages/design-system/src/PublicContracts.stories.mdx
@@ -7,7 +7,7 @@ import Navigation from './Navigation'
 import Progress from './Progress'
 import Table from './Table'
 import Workflow from './Workflow'
-import { Calendar } from './ui/calendar'
+import { Calendar } from './Calendar'
 
 {/* START README */}
 <div className="prose prose-sm max-w-none">
@@ -119,6 +119,10 @@ export const Default = () => (
       colorLabel="Contract colour"
       triggerAriaLabel="Contract colour picker"
       data={{ cy: 'contract-colorpicker', test: 'contract-colorpicker' }}
+      dataTrigger={{
+        cy: 'contract-colorpicker-trigger',
+        test: 'contract-colorpicker-trigger',
+      }}
       dataHexInput={{
         cy: 'contract-hex-input',
         test: 'contract-hex-input',
@@ -129,6 +133,10 @@ export const Default = () => (
       date={undefined}
       onDateChange={() => undefined}
       data={{ cy: 'contract-datepicker', test: 'contract-datepicker' }}
+      dataTrigger={{
+        cy: 'contract-datepicker-trigger',
+        test: 'contract-datepicker-trigger',
+      }}
       dataCalendar={{
         cy: 'contract-datepicker-calendar',
         test: 'contract-datepicker-calendar',
@@ -149,6 +157,10 @@ export const Default = () => (
       data={{
         cy: 'contract-datetimepicker',
         test: 'contract-datetimepicker',
+      }}
+      dataTrigger={{
+        cy: 'contract-datetimepicker-trigger',
+        test: 'contract-datetimepicker-trigger',
       }}
     />
   </div>

--- a/packages/design-system/src/Select.stories.mdx
+++ b/packages/design-system/src/Select.stories.mdx
@@ -285,7 +285,7 @@ const complexGroups = [
   groups={complexGroups}
   value={selectedIde}
   onChange={setSelectedIde}
-  data={{ 'data-cy': 'ide-selector' }}
+  data={{ cy: 'ide-selector' }}
 />
 ```
 

--- a/packages/design-system/src/Slider.stories.mdx
+++ b/packages/design-system/src/Slider.stories.mdx
@@ -252,8 +252,8 @@ const percentageColors = Object.fromEntries(
   min={0}
   max={5}
   step={1}
-  data={{ 'data-cy': 'rating-slider' }}
-  dataThumb={{ 'data-testid': 'slider-thumb' }}
+  data={{ cy: 'rating-slider' }}
+  dataThumb={{ test: 'slider-thumb' }}
   id="test-slider"
 />
 ```

--- a/packages/design-system/src/Switch.stories.mdx
+++ b/packages/design-system/src/Switch.stories.mdx
@@ -262,7 +262,7 @@ const [settings, setSettings] = useState({
   checked={testValue}
   label="Test Switch"
   onCheckedChange={setTestValue}
-  data={{ 'data-cy': 'test-switch' }}
+  data={{ cy: 'test-switch' }}
   id="test-switch"
 />
 ```

--- a/packages/design-system/src/Tabs.stories.mdx
+++ b/packages/design-system/src/Tabs.stories.mdx
@@ -266,27 +266,27 @@ const [validationErrors, setValidationErrors] = useState({})
       id: 'test-tab1',
       value: 'test-tab1',
       label: 'Tab 1',
-      data: { 'data-cy': 'tab-1-trigger' }
+      data: { cy: 'tab-1-trigger' }
     },
     {
       id: 'test-tab2',
       value: 'test-tab2',
       label: 'Tab 2',
-      data: { 'data-cy': 'tab-2-trigger' }
+      data: { cy: 'tab-2-trigger' }
     }
   ]}
   id="test-tabs"
 >
   <TabContent
     value="test-tab1"
-    data={{ 'data-testid': 'tab-1-content' }}
+    data={{ test: 'tab-1-content' }}
   >
     Tab 1 Content
   </TabContent>
 
   <TabContent
     value="test-tab2"
-    data={{ 'data-testid': 'tab-2-content' }}
+    data={{ test: 'tab-2-content' }}
   >
     Tab 2 Content
   </TabContent>

--- a/packages/design-system/src/Tooltip.stories.mdx
+++ b/packages/design-system/src/Tooltip.stories.mdx
@@ -234,8 +234,8 @@ Usage Examples:
 // Testing configuration
 <Tooltip
   tooltip="Test tooltip content"
-  data={{ 'data-cy': 'help-trigger' }}
-  dataContent={{ 'data-testid': 'tooltip-content' }}
+  data={{ cy: 'help-trigger' }}
+  dataContent={{ test: 'tooltip-content' }}
   id="test-tooltip"
 >
   <TestComponent />

--- a/packages/design-system/src/forms/FormikColorPicker.tsx
+++ b/packages/design-system/src/forms/FormikColorPicker.tsx
@@ -4,6 +4,7 @@ import { IconDefinition } from '@fortawesome/free-regular-svg-icons'
 import { useField } from 'formik'
 import React, { useEffect } from 'react'
 import ColorPicker, { ColorPickerClassName } from '../ColorPicker'
+import { type TestSelectors } from '../lib/testSelectors'
 
 export interface FormikColorPickerProps {
   name: string
@@ -20,22 +21,10 @@ export interface FormikColorPickerProps {
   colorLabel: string
   triggerAriaLabel: string
   colorTooltip?: string
-  data?: {
-    cy?: string
-    test?: string
-  }
-  dataTrigger?: {
-    cy?: string
-    test?: string
-  }
-  dataHexInput?: {
-    cy?: string
-    test?: string
-  }
-  dataSubmit?: {
-    cy?: string
-    test?: string
-  }
+  data?: TestSelectors
+  dataTrigger?: TestSelectors
+  dataHexInput?: TestSelectors
+  dataSubmit?: TestSelectors
   className?: ColorPickerClassName
 }
 

--- a/packages/design-system/src/forms/FormikColorPicker.tsx
+++ b/packages/design-system/src/forms/FormikColorPicker.tsx
@@ -20,6 +20,10 @@ export interface FormikColorPickerProps {
   colorLabel: string
   triggerAriaLabel: string
   colorTooltip?: string
+  data?: {
+    cy?: string
+    test?: string
+  }
   dataTrigger?: {
     cy?: string
     test?: string
@@ -52,6 +56,7 @@ export interface FormikColorPickerProps {
  * @param colorLabel - The label for the color input field.
  * @param triggerAriaLabel - Accessible name for the icon-only trigger button. Required, since the trigger has no visible text.
  * @param colorTooltip - Optional tooltip for the color input field.
+ * @param data - Optional data attributes for the component root (for testing purposes).
  * @param dataTrigger - Optional data attributes for the trigger icon (for testing purposes).
  * @param dataHexInput - Optional data attributes for the hex input field (for testing purposes).
  * @returns A ColorPicker component that integrates with Formik for form handling.
@@ -75,6 +80,7 @@ export function FormikColorPicker({
   colorLabel,
   triggerAriaLabel,
   colorTooltip,
+  data,
   dataTrigger,
   dataHexInput,
   dataSubmit,
@@ -108,6 +114,7 @@ export function FormikColorPicker({
       colorTooltip={colorTooltip}
       error={meta.error}
       isTouched={meta.touched}
+      data={data}
       dataTrigger={dataTrigger}
       dataHexInput={dataHexInput}
       dataSubmit={dataSubmit}

--- a/packages/design-system/src/forms/Label.stories.mdx
+++ b/packages/design-system/src/forms/Label.stories.mdx
@@ -206,7 +206,7 @@ Usage Examples:
   required
   tooltip="This is a test tooltip"
   showTooltipSymbol
-  data={{ 'data-cy': 'test-label' }}
+  data={{ cy: 'test-label' }}
   id="test-label-element"
 />
 

--- a/packages/design-system/src/forms/NumberField.stories.mdx
+++ b/packages/design-system/src/forms/NumberField.stories.mdx
@@ -332,8 +332,8 @@ const [settings, setSettings] = useState({
   value={testValue}
   onChange={setTestValue}
   data={{
-    'data-cy': 'number-input',
-    'data-testid': 'number-field'
+    cy: 'number-input',
+    test: 'number-field'
   }}
   id="test-number-field"
 />

--- a/packages/design-system/src/forms/SelectField.stories.mdx
+++ b/packages/design-system/src/forms/SelectField.stories.mdx
@@ -318,8 +318,8 @@ const getStatusOptions = () => {
   value={testValue}
   onChange={setTestValue}
   data={{
-    'data-cy': 'select-field',
-    'data-testid': 'select-dropdown'
+    cy: 'select-field',
+    test: 'select-dropdown'
   }}
   id="test-select-field"
 />

--- a/packages/design-system/src/forms/TextField.stories.mdx
+++ b/packages/design-system/src/forms/TextField.stories.mdx
@@ -317,8 +317,8 @@ const [touched, setTouched] = useState({})
   value={testValue}
   onChange={setTestValue}
   data={{
-    'data-cy': 'test-input',
-    'data-testid': 'text-field-input'
+    cy: 'test-input',
+    test: 'text-field-input'
   }}
   id="test-text-field"
 />

--- a/packages/design-system/src/forms/TextareaField.stories.mdx
+++ b/packages/design-system/src/forms/TextareaField.stories.mdx
@@ -350,8 +350,8 @@ useEffect(() => {
   onChange={setTestValue}
   placeholder="Enter test content"
   data={{
-    'data-cy': 'textarea-input',
-    'data-testid': 'textarea-field'
+    cy: 'textarea-input',
+    test: 'textarea-field'
   }}
   id="test-textarea"
 />

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,5 +1,7 @@
 import './tailwind.css'
 
+export type { TestSelectors } from './lib/testSelectors'
+
 export * from './Accordion'
 export * from './Alert'
 export * from './AlertDialog'

--- a/packages/design-system/src/lib/testSelectors.ts
+++ b/packages/design-system/src/lib/testSelectors.ts
@@ -1,0 +1,32 @@
+/**
+ * The v5 test-selector contract.
+ *
+ * A selector prop carries exactly this shape and renders as `data-cy` /
+ * `data-test`. `data-testid` is not part of the contract and is never emitted.
+ *
+ * Both the type and the attribute names live here so neither is retyped at a
+ * call site. The `data-text` typo that shipped in `ColorPicker` for three
+ * years was possible only because every render site spelled the attribute out
+ * by hand.
+ */
+export type TestSelectors = {
+  cy?: string
+  test?: string
+}
+
+/**
+ * Spread onto the element a selector prop addresses:
+ *
+ * ```tsx
+ * <div {...testAttrs(data)} />
+ * ```
+ *
+ * Both keys are always present, so an unset selector renders no attribute
+ * rather than an empty one, and JSX spread precedence stays predictable.
+ */
+export function testAttrs(data?: TestSelectors) {
+  return {
+    'data-cy': data?.cy,
+    'data-test': data?.test,
+  }
+}

--- a/packages/design-system/src/lib/testSelectors.ts
+++ b/packages/design-system/src/lib/testSelectors.ts
@@ -21,12 +21,15 @@ export type TestSelectors = {
  * <div {...testAttrs(data)} />
  * ```
  *
- * Both keys are always present, so an unset selector renders no attribute
- * rather than an empty one, and JSX spread precedence stays predictable.
+ * Only keys that carry a value are emitted, so the result is safe to spread in
+ * any position: an unset selector cannot blank an attribute that a neighbouring
+ * spread supplied. Emitting both keys unconditionally would make a spread-last
+ * call destructive, which is the same silent attribute loss this module exists
+ * to prevent.
  */
 export function testAttrs(data?: TestSelectors) {
   return {
-    'data-cy': data?.cy,
-    'data-test': data?.test,
+    ...(data?.cy !== undefined && { 'data-cy': data.cy }),
+    ...(data?.test !== undefined && { 'data-test': data.test }),
   }
 }

--- a/packages/design-system/src/primitives.ts
+++ b/packages/design-system/src/primitives.ts
@@ -1,5 +1,7 @@
 import './tailwind.css'
 
+export type { TestSelectors } from './lib/testSelectors'
+
 export * from './ui/accordion'
 export * from './ui/alert'
 export * from './ui/alert-dialog'

--- a/packages/design-system/src/ui/calendar.tsx
+++ b/packages/design-system/src/ui/calendar.tsx
@@ -19,11 +19,13 @@ function Calendar({
   buttonVariant = 'ghost',
   formatters,
   components,
+  data,
   dataPreviousMonth,
   dataNextMonth,
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>['variant']
+  data?: { cy?: string; test?: string }
   dataPreviousMonth?: { cy?: string; test?: string }
   dataNextMonth?: { cy?: string; test?: string }
 }) {
@@ -31,6 +33,8 @@ function Calendar({
 
   return (
     <DayPicker
+      data-cy={data?.cy}
+      data-test={data?.test}
       showOutsideDays={showOutsideDays}
       className={cn(
         'group/calendar border-border bg-background text-foreground w-fit min-w-[280px] rounded-lg border p-4 shadow-lg [--cell-size:34px] in-data-[slot=card-content]:bg-transparent',

--- a/packages/design-system/src/ui/calendar.tsx
+++ b/packages/design-system/src/ui/calendar.tsx
@@ -8,6 +8,7 @@ import {
 import * as React from 'react'
 import { DayButton, DayPicker, getDefaultClassNames } from 'react-day-picker'
 
+import { testAttrs, type TestSelectors } from '../lib/testSelectors'
 import { cn } from '../lib/utils'
 import { Button, buttonVariants } from './button'
 
@@ -22,28 +23,18 @@ function Calendar({
   data,
   dataPreviousMonth,
   dataNextMonth,
-  'data-cy': dataCyAttribute,
-  'data-test': dataTestAttribute,
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>['variant']
-  data?: { cy?: string; test?: string }
-  dataPreviousMonth?: { cy?: string; test?: string }
-  dataNextMonth?: { cy?: string; test?: string }
-  'data-cy'?: string
-  'data-test'?: string
+  data?: TestSelectors
+  dataPreviousMonth?: TestSelectors
+  dataNextMonth?: TestSelectors
 }) {
   const defaultClassNames = getDefaultClassNames()
 
-  // Calendar accepts both the `data` prop and raw data-cy/data-test
-  // attributes, because the pickers forward their `dataCalendar` as raw
-  // attributes. A raw attribute wins, but only when it carries a value: the
-  // pickers always pass the key, so plain JSX spread precedence would let an
-  // unset dataCalendar blank a `data` prop that a direct caller had set.
   return (
     <DayPicker
-      data-cy={dataCyAttribute ?? data?.cy}
-      data-test={dataTestAttribute ?? data?.test}
+      {...testAttrs(data)}
       showOutsideDays={showOutsideDays}
       className={cn(
         'group/calendar border-border bg-background text-foreground w-fit min-w-[280px] rounded-lg border p-4 shadow-lg [--cell-size:34px] in-data-[slot=card-content]:bg-transparent',
@@ -163,8 +154,7 @@ function Calendar({
               <ChevronLeftIcon
                 className={cn('size-4', className)}
                 {...props}
-                data-cy={dataPreviousMonth?.cy}
-                data-test={dataPreviousMonth?.test}
+                {...testAttrs(dataPreviousMonth)}
               />
             )
           }
@@ -174,8 +164,7 @@ function Calendar({
               <ChevronRightIcon
                 className={cn('size-4', className)}
                 {...props}
-                data-cy={dataNextMonth?.cy}
-                data-test={dataNextMonth?.test}
+                {...testAttrs(dataNextMonth)}
               />
             )
           }

--- a/packages/design-system/src/ui/calendar.tsx
+++ b/packages/design-system/src/ui/calendar.tsx
@@ -35,10 +35,11 @@ function Calendar({
 }) {
   const defaultClassNames = getDefaultClassNames()
 
-  // An explicit data-cy/data-test attribute wins over the root data prop, but
-  // only when it carries a value. Callers such as DatePicker always pass the
-  // key, so relying on JSX spread precedence would let an undefined
-  // dataCalendar blank a root selector that was set.
+  // Calendar accepts both the `data` prop and raw data-cy/data-test
+  // attributes, because the pickers forward their `dataCalendar` as raw
+  // attributes. A raw attribute wins, but only when it carries a value: the
+  // pickers always pass the key, so plain JSX spread precedence would let an
+  // unset dataCalendar blank a `data` prop that a direct caller had set.
   return (
     <DayPicker
       data-cy={dataCyAttribute ?? data?.cy}

--- a/packages/design-system/src/ui/calendar.tsx
+++ b/packages/design-system/src/ui/calendar.tsx
@@ -22,19 +22,27 @@ function Calendar({
   data,
   dataPreviousMonth,
   dataNextMonth,
+  'data-cy': dataCyAttribute,
+  'data-test': dataTestAttribute,
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>['variant']
   data?: { cy?: string; test?: string }
   dataPreviousMonth?: { cy?: string; test?: string }
   dataNextMonth?: { cy?: string; test?: string }
+  'data-cy'?: string
+  'data-test'?: string
 }) {
   const defaultClassNames = getDefaultClassNames()
 
+  // An explicit data-cy/data-test attribute wins over the root data prop, but
+  // only when it carries a value. Callers such as DatePicker always pass the
+  // key, so relying on JSX spread precedence would let an undefined
+  // dataCalendar blank a root selector that was set.
   return (
     <DayPicker
-      data-cy={data?.cy}
-      data-test={data?.test}
+      data-cy={dataCyAttribute ?? data?.cy}
+      data-test={dataTestAttribute ?? data?.test}
       showOutsideDays={showOutsideDays}
       className={cn(
         'group/calendar border-border bg-background text-foreground w-fit min-w-[280px] rounded-lg border p-4 shadow-lg [--cell-size:34px] in-data-[slot=card-content]:bg-transparent',

--- a/packages/design-system/src/ui/calendar.tsx
+++ b/packages/design-system/src/ui/calendar.tsx
@@ -34,7 +34,6 @@ function Calendar({
 
   return (
     <DayPicker
-      {...testAttrs(data)}
       showOutsideDays={showOutsideDays}
       className={cn(
         'group/calendar border-border bg-background text-foreground w-fit min-w-[280px] rounded-lg border p-4 shadow-lg [--cell-size:34px] in-data-[slot=card-content]:bg-transparent',
@@ -186,6 +185,10 @@ function Calendar({
         ...components,
       }}
       {...props}
+      // Last, so the declared `data` prop wins over a raw data-cy/data-test
+      // arriving through {...props}. testAttrs omits unset keys, so a Calendar
+      // without `data` still lets that raw passthrough reach the DOM.
+      {...testAttrs(data)}
     />
   )
 }

--- a/packages/design-system/tests/contracts/test-selectors.types.ts
+++ b/packages/design-system/tests/contracts/test-selectors.types.ts
@@ -1,4 +1,7 @@
+import type * as React from 'react'
+
 import type {
+  Calendar,
   ColorPickerProps,
   DatePickerProps,
   DateRangePickerProps,
@@ -94,7 +97,9 @@ acceptsWorkflowProgressProps({
 
 // The five components that previously exposed per-element selectors but no way
 // to address their own root. The root prop carries the same value shape, and
-// the per-element props keep working alongside it.
+// the per-element props keep working alongside it. Calendar is pinned last: it
+// is the only one of the five that used to accept raw `data-cy`/`data-test`
+// attributes as well, so it carries a negative case proving that form is gone.
 
 function acceptsDatePickerProps(props: DatePickerProps) {
   return props
@@ -125,6 +130,13 @@ acceptsDateRangePickerProps({
   data: { cy: 'range' },
 })
 
+acceptsDateRangePickerProps({
+  range: undefined,
+  onRangeChange: () => undefined,
+  // @ts-expect-error Root selectors use the `{ cy, test }` shape only.
+  data: { 'data-testid': 'range' },
+})
+
 function acceptsDatetimePickerProps(props: DateTimePickerProps) {
   return props
 }
@@ -148,4 +160,37 @@ acceptsColorPickerProps({
   triggerAriaLabel: 'Colour picker',
   data: { cy: 'colorpicker' },
   dataHexInput: { cy: 'hex', test: 'hex' },
+})
+
+acceptsColorPickerProps({
+  color: '#aa0000',
+  onSubmit: () => undefined,
+  submitText: 'Submit',
+  colorLabel: 'Colour',
+  triggerAriaLabel: 'Colour picker',
+  // @ts-expect-error Root selectors use the `{ cy, test }` shape only.
+  data: { 'data-testid': 'colorpicker' },
+})
+
+function acceptsCalendarProps(props: React.ComponentProps<typeof Calendar>) {
+  return props
+}
+
+acceptsCalendarProps({
+  mode: 'single',
+  data: { cy: 'calendar', test: 'calendar' },
+  dataNextMonth: { cy: 'next' },
+  dataPreviousMonth: { cy: 'previous' },
+})
+
+acceptsCalendarProps({
+  mode: 'single',
+  // @ts-expect-error Root selectors use the `{ cy, test }` shape only.
+  data: { 'data-testid': 'calendar' },
+})
+
+acceptsCalendarProps({
+  mode: 'single',
+  // @ts-expect-error Calendar takes `data`; the raw attribute form was removed in v5.
+  'data-cy': 'calendar',
 })

--- a/packages/design-system/tests/contracts/test-selectors.types.ts
+++ b/packages/design-system/tests/contracts/test-selectors.types.ts
@@ -1,4 +1,8 @@
 import type {
+  ColorPickerProps,
+  DatePickerProps,
+  DateRangePickerProps,
+  DateTimePickerProps,
   TableProps,
   WorkflowProgressProps,
   WorkflowProps,
@@ -86,4 +90,62 @@ acceptsWorkflowProgressProps({
     { title: 'Step', progress: 0.5, data: { 'data-testid': 'step' } },
   ],
   onClick: () => undefined,
+})
+
+// The five components that previously exposed per-element selectors but no way
+// to address their own root. The root prop carries the same value shape, and
+// the per-element props keep working alongside it.
+
+function acceptsDatePickerProps(props: DatePickerProps) {
+  return props
+}
+
+acceptsDatePickerProps({
+  date: undefined,
+  onDateChange: () => undefined,
+  data: { cy: 'picker', test: 'picker' },
+  dataTrigger: { cy: 'trigger' },
+  dataCalendar: { test: 'calendar' },
+})
+
+acceptsDatePickerProps({
+  date: undefined,
+  onDateChange: () => undefined,
+  // @ts-expect-error Root selectors use the `{ cy, test }` shape only.
+  data: { 'data-testid': 'picker' },
+})
+
+function acceptsDateRangePickerProps(props: DateRangePickerProps) {
+  return props
+}
+
+acceptsDateRangePickerProps({
+  range: undefined,
+  onRangeChange: () => undefined,
+  data: { cy: 'range' },
+})
+
+function acceptsDatetimePickerProps(props: DateTimePickerProps) {
+  return props
+}
+
+acceptsDatetimePickerProps({ data: { cy: 'datetime', test: 'datetime' } })
+
+acceptsDatetimePickerProps({
+  // @ts-expect-error Root selectors are an object, not a bare string.
+  data: 'datetime',
+})
+
+function acceptsColorPickerProps(props: ColorPickerProps) {
+  return props
+}
+
+acceptsColorPickerProps({
+  color: '#aa0000',
+  onSubmit: () => undefined,
+  submitText: 'Submit',
+  colorLabel: 'Colour',
+  triggerAriaLabel: 'Colour picker',
+  data: { cy: 'colorpicker' },
+  dataHexInput: { cy: 'hex', test: 'hex' },
 })

--- a/packages/design-system/tests/contracts/test-selectors.types.ts
+++ b/packages/design-system/tests/contracts/test-selectors.types.ts
@@ -192,8 +192,9 @@ acceptsCalendarProps({
 // `data` is the supported form and is the one pinned here. Note this pins the
 // object-literal position only: TypeScript exempts hyphenated names from excess
 // property checks in JSX, so `<Calendar data-cy="x" />` still compiles and still
-// reaches the DOM through DayPicker's prop passthrough. It is undocumented
-// rather than rejected, and `data` now takes precedence over it.
+// reaches the DOM through DayPicker's prop passthrough. That form is
+// undocumented rather than rejected: it is not part of the contract, and the
+// behaviour of passing both it and `data` is unspecified.
 acceptsCalendarProps({
   mode: 'single',
   // @ts-expect-error Selectors go through `data`, not a raw attribute prop.

--- a/packages/design-system/tests/contracts/test-selectors.types.ts
+++ b/packages/design-system/tests/contracts/test-selectors.types.ts
@@ -189,8 +189,13 @@ acceptsCalendarProps({
   data: { 'data-testid': 'calendar' },
 })
 
+// `data` is the supported form and is the one pinned here. Note this pins the
+// object-literal position only: TypeScript exempts hyphenated names from excess
+// property checks in JSX, so `<Calendar data-cy="x" />` still compiles and still
+// reaches the DOM through DayPicker's prop passthrough. It is undocumented
+// rather than rejected, and `data` now takes precedence over it.
 acceptsCalendarProps({
   mode: 'single',
-  // @ts-expect-error Calendar takes `data`; the raw attribute form was removed in v5.
+  // @ts-expect-error Selectors go through `data`, not a raw attribute prop.
   'data-cy': 'calendar',
 })

--- a/packages/design-system/tests/smoke/test-selectors.spec.ts
+++ b/packages/design-system/tests/smoke/test-selectors.spec.ts
@@ -101,37 +101,64 @@ test.describe('selector contract', () => {
   }) => {
     await gotoStory(page, story)
 
-    // DatetimePicker is the one unmasked leak vector: it sets `data` with no
-    // `dataCalendar` and does spread the residual `{...props}` into <Calendar>.
-    // If the `data` destructuring is ever dropped, the root selector reaches
-    // the calendar too and the count below becomes 2. The DatePicker instance
-    // cannot prove this, because its own `dataCalendar` would mask a leak.
+    // DatetimePicker sets `data` and no `dataCalendar`, so nothing else can
+    // account for a second match: if the root selector ever reaches <Calendar>
+    // as well, this count becomes 2. Both pickers used to forward a residual
+    // `{...props}` into <Calendar>, which is exactly how that would happen;
+    // the spreads are gone, and this pins them staying gone.
     const root = page.locator('[data-cy="contract-datetimepicker"]')
     await expect(root).toHaveCount(1)
 
     // Assert the popover actually mounted before counting. A trigger locator
     // that silently fails to open would otherwise leave the count at 1 and pass
     // the leak guard vacuously.
-    await root.getByRole('button').first().click()
+    await page.locator('[data-cy="contract-datetimepicker-trigger"]').click()
     await expect(page.getByRole('dialog')).toBeVisible()
     await expect(root).toHaveCount(1)
+  })
 
-    // The per-element `dataCalendar` still names the calendar on the picker
-    // that sets one, so the popover carries its own selector rather than the
-    // root's.
-    // Dismiss explicitly: an outside click on the next trigger would be
-    // swallowed closing this popover instead of opening the next one.
-    await page.keyboard.press('Escape')
-    await expect(page.getByRole('dialog')).toHaveCount(0)
+  test('names the calendar through dataCalendar, not the root selector', async ({
+    page,
+  }) => {
+    await gotoStory(page, story)
 
-    const datePickerRoot = page.locator('[data-cy="contract-datepicker"]')
-    await datePickerRoot.getByRole('button').first().click()
+    await page.locator('[data-cy="contract-datepicker-trigger"]').click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+
     const calendar = page.locator('[data-cy="contract-datepicker-calendar"]')
     await expect(calendar).toHaveCount(1)
     await expect(calendar).toHaveAttribute(
       'data-test',
       'contract-datepicker-calendar'
     )
+  })
+
+  test('scopes the root selector to the trigger area on the popover pickers', async ({
+    page,
+  }) => {
+    await gotoStory(page, story)
+
+    // Following shadcn, PopoverTrigger and PopoverContent are siblings under
+    // Popover rather than nested in a shared wrapper, so on the three date
+    // pickers the root selector marks the trigger area and does NOT contain
+    // the popover. MIGRATION.md states this; pin it so the two cannot drift.
+    await page.locator('[data-cy="contract-datepicker-trigger"]').click()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    const root = page.locator('[data-cy="contract-datepicker"]')
+    await expect(root.getByRole('dialog')).toHaveCount(0)
+
+    // ColorPicker is the counter-example: its root div wraps its own Popover,
+    // so the identical query does find the content there. Same prop name, two
+    // different scopes — asserted here so the asymmetry is visible rather than
+    // discovered by a consumer.
+    await page.keyboard.press('Escape')
+    await expect(dialog).toHaveCount(0)
+
+    await page.locator('[data-cy="contract-colorpicker-trigger"]').click()
+    const colorPickerRoot = page.locator('[data-cy="contract-colorpicker"]')
+    await expect(colorPickerRoot.getByRole('dialog')).toHaveCount(1)
   })
 
   test('renders the ColorPicker hex input selector as data-test', async ({

--- a/packages/design-system/tests/smoke/test-selectors.spec.ts
+++ b/packages/design-system/tests/smoke/test-selectors.spec.ts
@@ -101,25 +101,37 @@ test.describe('selector contract', () => {
   }) => {
     await gotoStory(page, story)
 
-    // The root `data` is destructured in DatePicker, so it must not reach the
-    // Calendar through the residual `{...props}` spread. If it leaks, the
-    // selector renders inside the popover instead of on the root.
-    const root = page.locator('[data-cy="contract-datepicker"]')
+    // DatetimePicker is the one unmasked leak vector: it sets `data` with no
+    // `dataCalendar` and does spread the residual `{...props}` into <Calendar>.
+    // If the `data` destructuring is ever dropped, the root selector reaches
+    // the calendar too and the count below becomes 2. The DatePicker instance
+    // cannot prove this, because its own `dataCalendar` would mask a leak.
+    const root = page.locator('[data-cy="contract-datetimepicker"]')
     await expect(root).toHaveCount(1)
-    await expect(root.locator('[data-cy="contract-datepicker"]')).toHaveCount(0)
 
-    // Opening the popover shows the per-element `dataCalendar` selector, which
-    // still wins on the calendar it names. This is the precedence guard: an
-    // explicit data-cy attribute beats the root prop on that element, and the
-    // root prop must not overwrite it.
+    // Assert the popover actually mounted before counting. A trigger locator
+    // that silently fails to open would otherwise leave the count at 1 and pass
+    // the leak guard vacuously.
     await root.getByRole('button').first().click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(root).toHaveCount(1)
+
+    // The per-element `dataCalendar` still names the calendar on the picker
+    // that sets one, so the popover carries its own selector rather than the
+    // root's.
+    // Dismiss explicitly: an outside click on the next trigger would be
+    // swallowed closing this popover instead of opening the next one.
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+
+    const datePickerRoot = page.locator('[data-cy="contract-datepicker"]')
+    await datePickerRoot.getByRole('button').first().click()
     const calendar = page.locator('[data-cy="contract-datepicker-calendar"]')
     await expect(calendar).toHaveCount(1)
     await expect(calendar).toHaveAttribute(
       'data-test',
       'contract-datepicker-calendar'
     )
-    await expect(calendar).not.toHaveAttribute('data-cy', 'contract-datepicker')
   })
 
   test('renders the ColorPicker hex input selector as data-test', async ({

--- a/packages/design-system/tests/smoke/test-selectors.spec.ts
+++ b/packages/design-system/tests/smoke/test-selectors.spec.ts
@@ -71,4 +71,72 @@ test.describe('selector contract', () => {
       await expect(root).not.toHaveAttribute('data-test', /.*/)
     }
   })
+
+  test('renders root selectors on the picker and calendar roots', async ({
+    page,
+  }) => {
+    await gotoStory(page, story)
+
+    // Four of the five are popover-based. Their root selector sits on the
+    // wrapper outside the popover content, so it must be present and visible
+    // without opening anything.
+    const roots = [
+      'contract-calendar',
+      'contract-colorpicker',
+      'contract-datepicker',
+      'contract-daterangepicker',
+      'contract-datetimepicker',
+    ] as const
+
+    for (const selector of roots) {
+      const root = page.locator(`[data-cy="${selector}"]`)
+      await expect(root).toHaveCount(1)
+      await expect(root).toHaveAttribute('data-test', selector)
+      await expect(root).toBeVisible()
+    }
+  })
+
+  test('keeps the picker root selector off the calendar in the popover', async ({
+    page,
+  }) => {
+    await gotoStory(page, story)
+
+    // The root `data` is destructured in DatePicker, so it must not reach the
+    // Calendar through the residual `{...props}` spread. If it leaks, the
+    // selector renders inside the popover instead of on the root.
+    const root = page.locator('[data-cy="contract-datepicker"]')
+    await expect(root).toHaveCount(1)
+    await expect(root.locator('[data-cy="contract-datepicker"]')).toHaveCount(0)
+
+    // Opening the popover shows the per-element `dataCalendar` selector, which
+    // still wins on the calendar it names. This is the precedence guard: an
+    // explicit data-cy attribute beats the root prop on that element, and the
+    // root prop must not overwrite it.
+    await root.getByRole('button').first().click()
+    const calendar = page.locator('[data-cy="contract-datepicker-calendar"]')
+    await expect(calendar).toHaveCount(1)
+    await expect(calendar).toHaveAttribute(
+      'data-test',
+      'contract-datepicker-calendar'
+    )
+    await expect(calendar).not.toHaveAttribute('data-cy', 'contract-datepicker')
+  })
+
+  test('renders the ColorPicker hex input selector as data-test', async ({
+    page,
+  }) => {
+    await gotoStory(page, story)
+
+    // Regression guard for the misspelled `data-text` that shipped from
+    // f7cd6d65: the value is typed correctly but never reached the DOM.
+    const trigger = page.locator('[data-cy="contract-colorpicker"]')
+    await trigger
+      .getByRole('button', { name: 'Contract colour picker' })
+      .click()
+
+    const hexInput = page.locator('[data-cy="contract-hex-input"]')
+    await expect(hexInput).toHaveCount(1)
+    await expect(hexInput).toHaveAttribute('data-test', 'contract-hex-input')
+    await expect(hexInput).not.toHaveAttribute('data-text', /.*/)
+  })
 })

--- a/packages/design-system/tests/smoke/test-selectors.spec.ts
+++ b/packages/design-system/tests/smoke/test-selectors.spec.ts
@@ -103,9 +103,13 @@ test.describe('selector contract', () => {
 
     // DatetimePicker sets `data` and no `dataCalendar`, so nothing else can
     // account for a second match: if the root selector ever reaches <Calendar>
-    // as well, this count becomes 2. Both pickers used to forward a residual
-    // `{...props}` into <Calendar>, which is exactly how that would happen;
-    // the spreads are gone, and this pins them staying gone.
+    // as well, this count becomes 2.
+    //
+    // Be precise about what this does and does not catch. Re-adding a residual
+    // `{...props}` spread into <Calendar> alone does NOT trip it, because `data`
+    // is destructured out of the rest. It fails only on the pair: a rest spread
+    // reaching <Calendar> AND `data` left undestructured. That pair was
+    // reproduced against a clean rebuild and gave `Expected: 1, Received: 2`.
     const root = page.locator('[data-cy="contract-datetimepicker"]')
     await expect(root).toHaveCount(1)
 
@@ -159,6 +163,45 @@ test.describe('selector contract', () => {
     await page.locator('[data-cy="contract-colorpicker-trigger"]').click()
     const colorPickerRoot = page.locator('[data-cy="contract-colorpicker"]')
     await expect(colorPickerRoot.getByRole('dialog')).toHaveCount(1)
+  })
+
+  test('renders the per-element selectors that need no popover', async ({
+    page,
+  }) => {
+    await gotoStory(page, story)
+
+    // The Calendar chevrons spread their selectors AFTER the forwarded
+    // `{...props}`, which is the placement most likely to be dropped by a
+    // refactor, and they are reachable without opening anything.
+    for (const selector of [
+      'contract-calendar-next',
+      'contract-calendar-previous',
+      'contract-daterangepicker-trigger',
+      'contract-datepicker-trigger',
+      'contract-datetimepicker-trigger',
+      'contract-colorpicker-trigger',
+    ] as const) {
+      const element = page.locator(`[data-cy="${selector}"]`)
+      await expect(element).toHaveCount(1)
+      await expect(element).toHaveAttribute('data-test', selector)
+    }
+  })
+
+  test('renders the DatetimePicker time-input selectors', async ({ page }) => {
+    await gotoStory(page, story)
+
+    // These reach the DOM through TimePickerInput's own rest spread into
+    // <Input>, so they are the longest forwarding chain in the contract.
+    await page.locator('[data-cy="contract-datetimepicker-trigger"]').click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+
+    for (const selector of [
+      'contract-datetimepicker-hours',
+      'contract-datetimepicker-minutes',
+      'contract-datetimepicker-seconds',
+    ] as const) {
+      await expect(page.locator(`[data-cy="${selector}"]`)).toHaveCount(1)
+    }
   })
 
   test('renders the ColorPicker hex input selector as data-test', async ({

--- a/packages/design-system/tsconfig.types.json
+++ b/packages/design-system/tsconfig.types.json
@@ -5,10 +5,5 @@
     "noEmit": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.types.tsbuildinfo"
   },
-  "include": [
-    "tests/contracts/public-contracts.types.ts",
-    "tests/contracts/direct-control-refs.types.ts",
-    "tests/contracts/composite-refs.types.ts",
-    "tests/contracts/test-selectors.types.ts"
-  ]
+  "include": ["tests/contracts/**/*.types.ts"]
 }

--- a/project/2026-08-02-v5-post-a3-next-roadmap.md
+++ b/project/2026-08-02-v5-post-a3-next-roadmap.md
@@ -197,18 +197,30 @@ W1 is ready for orchestrator review only when the diff is limited to the owned
 
 ### W2 — inventory-backed selector rollout (future, gated on W1)
 
-Build a current inventory from source, stories, and public examples. Classify
-each interactive component as primary-only, multiple-control, or intentionally
-non-interactive. Retrofit only the approved public set:
+Superseded in scope by the inventory taken at `2fc8f915`. The migration this
+section anticipated was already complete: no `dataAttributes`, `dataX`, or
+`Record<string, string>` selector form survives anywhere in shipped source, and
+no `.tsx` under `src` contains `data-testid`. `Table` was the last holdout and
+W1 closed it. What W2 actually carries is recorded in
+`project/2026-08-03-v5-w2-selector-rollout-plan.md`:
 
-- migrate remaining `dataAttributes`, `dataX`, and `Record<string, string>`
-  forms to the same `{ cy, test }` value shape;
+- add a root `data` prop to `Calendar`, `ColorPicker`, `DatePicker`,
+  `DateRangePicker`, and `DatetimePicker`, which exposed per-element selectors
+  but no way to address their own root (user ruling, 2026-08-03);
+- do not retrofit the 37 components that expose no selector prop; they gain one
+  on demand when a consumer needs it (user ruling, 2026-08-03);
 - retain named sub-element props for Modal, picker popovers, and similar
-  multi-control components only when their values use that shape;
+  multi-control components, whose values already use the correct shape;
+- fix `ColorPicker` rendering `dataHexInput.test` as a misspelled `data-text`;
 - update stories and `MIGRATION.md` with before/after examples;
 - add inventory-backed DOM contracts, not a global search-and-replace;
 - leave deprecated Formik components, passive layout components, and unrelated
   consumer examples out unless a separately approved package policy changes.
+
+The story corpus was larger than W1 recorded: 15 files, not 8. W1 scanned only
+for `data-testid`, which missed record-shape examples written with `data-cy`
+alone and the whole `src/forms/` tree. Five non-deprecated forms stories were in
+scope; the eight deprecated `Formik*` stories stay as they are.
 
 W2 cannot start until W1's location and naming contract is reviewed and merged.
 

--- a/project/2026-08-02-v5-post-a3-next-roadmap.md
+++ b/project/2026-08-02-v5-post-a3-next-roadmap.md
@@ -198,9 +198,10 @@ W1 is ready for orchestrator review only when the diff is limited to the owned
 ### W2 — inventory-backed selector rollout (future, gated on W1)
 
 Superseded in scope by the inventory taken at `2fc8f915`. The migration this
-section anticipated was already complete: no `dataAttributes`, `dataX`, or
-`Record<string, string>` selector form survives anywhere in shipped source, and
-no `.tsx` under `src` contains `data-testid`. `Table` was the last holdout and
+section anticipated was already complete: no deviant selector value shape
+survives anywhere in shipped source — no `dataAttributes` prop name, no
+attribute record, nothing permitting `data-testid`. The named per-element props
+themselves are retained; it is their value shape that is now uniform. `Table` was the last holdout and
 W1 closed it. What W2 actually carries is recorded in
 `project/2026-08-03-v5-w2-selector-rollout-plan.md`:
 

--- a/project/2026-08-03-v5-w2-selector-rollout-plan.md
+++ b/project/2026-08-03-v5-w2-selector-rollout-plan.md
@@ -307,8 +307,16 @@ review after verification, before the PR is published.
   left two contradicting conventions in one list. The equivalent stale lines in
   `Modal`, `Header`, `Navigation` and others remain; `MIGRATION.md` now says so
   rather than claiming the corpus is clean.
-- 2026-08-03: Ladle's production build drops `.stories.mdx` prose entirely — it
-  appears in neither `build/assets/` nor `meta.json`. Pre-existing behaviour, not
-  a branch regression (prose never touched by this branch is absent too), but it
-  means story documentation cannot be verified through the built bundle and the
-  freshness check above does not cover it.
+- 2026-08-03: which parts of a `.stories.mdx` actually reach the rendered page.
+  An earlier note here claimed Ladle drops story prose wholesale; that was wrong,
+  and the grep that suggested it had picked a phrase living in the dropped half.
+  The real split: text inside the `{/* START README */}` `<div>` compiles into the
+  story chunk, while everything inside the `{/* AI_DOCUMENTATION ... */}` comment
+  is an MDX comment and never renders. Verified per file against `build/assets/`:
+  the new root `data` entries for `ColorPicker`, `DatePicker` and `DatetimePicker`
+  sit in the README `<div>` and are present in their built chunks; `Calendar` and
+  `DateRangePicker` have prose-only READMEs with no prop list at all, so their
+  `data` entries live in the AI_DOCUMENTATION block and render nowhere. That is
+  the right home for them given those two files document no other prop in the
+  README, but it means the Ladle page for those two does not advertise the new
+  prop. Left as is rather than introducing a prop list those files never had.

--- a/project/2026-08-03-v5-w2-selector-rollout-plan.md
+++ b/project/2026-08-03-v5-w2-selector-rollout-plan.md
@@ -364,3 +364,42 @@ review after verification, before the PR is published.
 - 2026-08-03: post-gate verification, all green — `pnpm check`, `pnpm lint`,
   `pnpm format:check`, `pnpm build`, `build:ladle` clean, full Playwright suite
   1247 passed (up from 1245: the leak guard was split into three focused tests).
+- 2026-08-03: gate re-run against `911de6bf` returned APPROVE-WITH-FOLLOWUP with
+  eight findings, none blocking, and one of them corrected a claim this branch
+  had made in three places at once. Its own least-confident point was the crux,
+  so it was settled empirically rather than accepted: a scratch `tsc` probe
+  confirms `<Calendar mode="single" data-cy="x" />` still compiles. Removing the
+  declared `'data-cy'`/`'data-test'` props did NOT remove the raw-attribute
+  path — hyphenated names are exempt from excess-property checking in JSX, and
+  the attribute still reaches the DOM through the trailing `{...props}`. The
+  commit message, `MIGRATION.md` and a `@ts-expect-error` all said otherwise.
+  Resolved by making the code match the intent rather than softening the claim:
+  `testAttrs` now omits unset keys, and `{...testAttrs(data)}` moved to last in
+  `calendar.tsx` so the declared prop wins while an unset `data` still lets the
+  raw passthrough work. The fixture comment now says it pins the object-literal
+  position only.
+- 2026-08-03: `testAttrs` emitting both keys unconditionally was a latent trap.
+  A spread-last call would have blanked whatever a preceding spread supplied —
+  the same silent attribute loss the module exists to prevent, and `calendar.tsx`
+  used both spread positions. Omitting unset keys makes placement safe in either
+  position, which the Calendar chevron tests now cover directly.
+- 2026-08-03: the trigger-area correction had been applied to `MIGRATION.md`
+  only. Six further prop-reference sites — the three date-picker JSDoc blocks and
+  their story prop lists — still called it the component root, which is the
+  higher-traffic surface since it is what Ladle renders. All six corrected;
+  `ColorPicker` and `Calendar` legitimately say "component root" and were left.
+- 2026-08-03: `TestSelectors` exported from both `src/index.ts` and
+  `src/primitives.ts`. Without it the type had no public name, so a consumer
+  wanting to hoist a selector object would retype the literal — reproducing
+  outside the package exactly the duplication removed inside it. It is also the
+  cheapest brake on the two-idiom drift while the remaining 49 files wait on the
+  mechanical follow-up.
+- 2026-08-03: six converted render sites had no DOM coverage (the three
+  DatetimePicker time inputs, both Calendar chevrons, the DateRangePicker
+  trigger). The chevrons matter most because they spread selectors AFTER the
+  forwarded `{...props}`. Added to the contract story and pinned by two new
+  tests, taking the selector spec from 7 to 9 cases.
+- 2026-08-03: `MIGRATION.md` now also records that `DatePicker` no longer
+  forwards undeclared props to its calendar. Typed callers were never able to
+  pass them, but an untyped JavaScript caller relying on the pass-through to
+  reach a react-day-picker option loses it silently, which belongs in the guide.

--- a/project/2026-08-03-v5-w2-selector-rollout-plan.md
+++ b/project/2026-08-03-v5-w2-selector-rollout-plan.md
@@ -1,0 +1,268 @@
+# W2 — selector rollout completion (v5)
+
+Branch: `rs/v5-selector-rollout` · Worktree: `trees/rs-v5-selector-rollout`
+Base: `v5` at `2fc8f915` (merge of [PR #190](https://github.com/uzh-bf/design-system/pull/190), W1)
+Plan owner: this file. Roadmap: `project/2026-08-02-v5-post-a3-next-roadmap.md`.
+
+## Why this slice is smaller than the roadmap predicted
+
+W2 was scoped as an "inventory-backed rollout" that would migrate remaining
+`dataAttributes`, `dataX`, and `Record<string, string>` selector forms onto the
+v5 `{ cy?: string; test?: string }` shape. A full inventory taken at `2fc8f915`
+shows that migration is already complete:
+
+| Shape | Components | Notes |
+| --- | --- | --- |
+| Unified `data` prop only | 22 | Includes `Table` and `Workflow` from W1 |
+| Named per-element `dataX` props only | 5 | `Calendar`, `ColorPicker`, `DatePicker`, `DateRangePicker`, `DatetimePicker` |
+| Both `data` and per-element props | 3 | `Modal`, `Slider`, `Tooltip` |
+| No selector prop at all | 37 | `Card`, `Popover`, `Sidebar`, `Accordion`, and similar |
+| Legacy or deviant value shape | 0 | No `dataAttributes`, no attribute record, nothing permitting `data-testid` |
+
+That table counts the 67 top-level `src/*.tsx` components only, resolving
+inherited props through `src/ui/*.tsx`. The 17 `src/forms/*.tsx` components were
+inventoried separately and also carry no deviant value shapes.
+`src/original/*.tsx` is dead code, imported by nothing in `src` or `tests`, and
+is excluded throughout.
+
+Every selector prop in shipped source already carries the exact v5 shape, and no
+`.tsx` file under `src` contains `data-testid`. `Table` was the last holdout and
+W1 closed it. So W2 is not a type migration. What remains is one wiring defect,
+an API asymmetry, and a documentation corpus that still teaches the pre-v5
+shape.
+
+## Rulings that scope this slice
+
+Ruled by the user on 2026-08-03, before implementation:
+
+1. **Root `data` on the five per-element-only components: yes.** `Calendar`,
+   `ColorPicker`, `DatePicker`, `DateRangePicker`, and `DatetimePicker` gain a
+   component-level `data` prop, matching `Modal`, `Slider`, and `Tooltip`, which
+   already expose both. Purely additive; no existing call site breaks.
+2. **Blanket retrofit of the 37 selectorless components: no.** They stay as
+   they are. Role- and label-based queries already address them, and a component
+   gains `data` later when a real consumer needs it.
+
+Decided by the agent during plan review, subject to the user's veto:
+
+3. **`FormikColorPicker` gets the root pass-through.** See W2.2 and boundary 5.
+
+## Work packages
+
+### W2.1 — fix the ColorPicker selector wiring defect
+
+`src/ColorPicker.tsx:253` renders `data-text={dataHexInput?.test}`. The attribute
+name is misspelled, so a correctly typed `dataHexInput.test` value never reaches
+the DOM. The declared type at `src/ColorPicker.tsx:52` is correct, which is why
+no type check catches it.
+
+Fix the attribute to `data-test`. The misspelling entered at `f7cd6d65` (PR #56,
+2023-06-15) with the component itself, so it has shipped in every release since;
+`557b339e` only relocated the file during the monorepo transform, which is why a
+path-scoped history search without `--follow` appears to stop there. `data-text`
+appears in no documented
+contract and was already logged as known debt in
+`project/2026-07-20-pr-182-v5-a11y-level-a-plan.md:208`. Treat it as a defect
+fix, and note it in `MIGRATION.md` under W2.6 since it is the one place a real
+Cypress assertion could break.
+
+### W2.2 — add root `data` to the five per-element-only components
+
+Add an optional `data?: { cy?: string; test?: string }` to each, rendered as
+`data-cy` / `data-test`. Do not follow "the Modal pattern": `Modal` and `Tooltip`
+render their root selector on the *trigger*, `Slider` on the component root, so
+there is no single established precedent. On the pickers the trigger element is
+already occupied by `dataTrigger` (`src/DatePicker.tsx:146`,
+`src/DateRangePicker.tsx:139`, `src/DatetimePicker.tsx:771`), and a second
+`data-cy` on the same JSX element is a TypeScript error.
+
+Exact target element per component:
+
+| Component | Target element | Note |
+| --- | --- | --- |
+| `ColorPicker` | outer `<div>` at `src/ColorPicker.tsx:135` | always mounted |
+| `DatePicker` | wrapper `<div>` at `src/DatePicker.tsx:112` | inside `<Popover>`, outside `<PopoverContent>`, so mounted when closed |
+| `DateRangePicker` | wrapper `<div>` at `src/DateRangePicker.tsx:110` | same structure |
+| `DatetimePicker` | wrapper `<div>` at `src/DatetimePicker.tsx:737` | same structure |
+| `Calendar` | `<DayPicker>` root at `src/ui/calendar.tsx:33` | declared alongside the existing props at `src/ui/calendar.tsx:27-28` |
+
+The root `data` must not land on a trigger `<Button>`; `dataTrigger` owns that
+element. Do not touch the existing per-element props: their shapes conform, and
+collapsing a multi-control API into one ambiguous selector is forbidden by
+boundary 4.
+
+Two prop-forwarding traps, both of which produce a wrong-looking DOM rather than
+a compile error:
+
+- `src/ui/calendar.tsx` spreads `{...props}` into `<DayPicker>` at line 186, and
+  its props type is `React.ComponentProps<typeof DayPicker> & {...}`. The new
+  `data` prop must be destructured out, or React forwards it as an
+  object-valued DOM attribute.
+- `DatePicker` and `DatetimePicker` spread `{...props}` into `<Calendar>`
+  (`src/DatePicker.tsx:198`, `src/DatetimePicker.tsx:857`). Once `data` exists on
+  their interfaces, an undestructured `data` lands on the calendar inside the
+  popover instead of the component root. Destructure it in the signature.
+
+`FormikDatePicker` and `FormikDatetimePicker` extend their base props and forward
+`{...props}`, so they inherit the new prop automatically.
+`src/forms/FormikColorPicker.tsx:8` declares a standalone interface with a closed
+prop list, so it inherits nothing. Add the root `data` pass-through there too,
+under the narrow exception in boundary 5, so the Formik path does not ship a
+selector on two of three pickers for no stated reason.
+
+### W2.3 — correct the story documentation corpus
+
+Story files document the pre-v5 attribute-record shape, for example
+`data={{ 'data-cy': 'x', 'data-testid': 'y' }}` where the supported form is
+`data={{ cy: 'x', test: 'y' }}`. None of it type-checks, because MDX prose and
+code fences are not compiled. Every affected line sits inside a ```tsx fence, so
+this package is DOM-neutral.
+
+Top-level stories, 22 code lines plus 2 prose lines across 10 files:
+
+| File | Defect |
+| --- | --- |
+| `DatePicker.stories.mdx` | 4 code lines, plus a prose claim of "both data-cy and data-testid" support |
+| `DatetimePicker.stories.mdx` | 4 code lines |
+| `Tabs.stories.mdx` | 4 code lines |
+| `Navigation.stories.mdx` | 2 code lines |
+| `Slider.stories.mdx` | 2 code lines |
+| `Tooltip.stories.mdx` | 2 code lines |
+| `Header.stories.mdx` | 1 code line carrying both keys |
+| `NotificationBadgeWrapper.stories.mdx` | 1 code line, plus the same prose claim |
+| `Select.stories.mdx` | 1 code line |
+| `Switch.stories.mdx` | 1 code line |
+
+Forms stories, 9 further code lines across 5 files: `TextField.stories.mdx`,
+`TextareaField.stories.mdx`, `NumberField.stories.mdx`,
+`SelectField.stories.mdx`, `Label.stories.mdx`. These five components carry no
+`@deprecated` marker, are exported from `src/index.ts`, and already declare the
+correct v5 shape, so the roadmap's carve-out for "deprecated Formik components"
+does not reach them.
+
+Deliberately excluded: the 8 `Formik*.stories.mdx` files, holding 28 further
+record-shape lines. They document the frozen, `@deprecated` Formik surface that
+the roadmap excludes at line 210. This is a recorded decision, not an oversight.
+
+W1's record listed 8 files because it scanned only for `data-testid`.
+`Select.stories.mdx` and `Switch.stories.mdx` use the record shape with `data-cy`
+alone, and the entire `src/forms/` tree went unscanned. This plan supersedes that
+count.
+
+Rewrite every in-scope example to the supported shape and delete the two prose
+claims that the library supports `data-testid`. It does not, at any level.
+
+Trap: `{ cy, test }` in MDX running text is parsed as a JSX expression and breaks
+the story at runtime. Use backticked field names in prose. Code fences are safe.
+
+### W2.4 — DOM contracts for the changed surface
+
+Extend `tests/smoke/test-selectors.spec.ts` and the type fixture
+`tests/contracts/test-selectors.types.ts` to cover the five new root props and
+the corrected `ColorPicker` attribute.
+
+CI runs `tests/smoke` and `tests/a11y` but not `tests/contracts`; type fixtures
+are enforced only by their entry in `tsconfig.types.json`. Runtime proof must
+live under `tests/smoke` to be gated.
+
+Four of the five are popover-based; `Calendar` renders inline via `<DayPicker>`
+and is always mounted. For the four, assert on the closed-state root, which the
+target table above places outside `<PopoverContent>`. Additionally assert that
+the calendar inside the popover does *not* carry the root selector, so the
+prop-forwarding trap in W2.2 cannot pass silently.
+
+Story surface: extend the existing `public-contracts--default` story that
+`tests/smoke/test-selectors.spec.ts:5` drives, rather than adding a story id.
+Note the consequence: a11y waivers in `tests/a11y/stories.spec.ts` are
+story-id-scoped, so markup moved onto a `public-contracts--` story loses the
+waiver it had under its own id. If any of the five carries a violation waived
+only under `calendar--`, `color-picker--`, `date-picker--`,
+`date-range-picker--`, or `datetime-picker--`, the a11y suite goes red. None of
+those prefixes appears in a current allowlist entry, so this is expected to be
+clean, but it is a stop-and-report condition rather than a licence to widen a
+waiver.
+
+### W2.5 — correct the roadmap's stale W2 section
+
+`project/2026-08-02-v5-post-a3-next-roadmap.md` describes migrating
+`dataAttributes` and `Record<string, string>` forms that do not exist at
+`2fc8f915`. Rewrite that section to match the inventory and record both user
+rulings. Preserve its `MIGRATION.md` obligation from line 208 rather than
+dropping it with the stale text.
+
+### W2.6 — update MIGRATION.md
+
+The roadmap assigns this to W2 at line 208. Three edits, all of which this slice
+makes necessary:
+
+- `MIGRATION.md:288-290` says stale `data-testid` story docs "are being
+  corrected". Restate it as what is actually true at the end of W2: the
+  top-level and non-deprecated forms stories are corrected; the deprecated
+  Formik stories still show the old shape.
+- `MIGRATION.md:292-297` describes a taxonomy where composites have *either* one
+  `data` prop *or* per-element props. W2.2 breaks that: the pickers will carry
+  both. Rewrite it, and while there, correct the `Modal` list, which names
+  `dataContent`/`dataCloseButton`/`dataPrimaryAction` but omits
+  `dataSecondaryAction`.
+- Add a line recording that `ColorPicker`'s `dataHexInput.test` now renders as
+  `data-test`, previously the misspelled `data-text`.
+
+## Boundaries
+
+Carried from the roadmap and still binding:
+
+1. `v5` is the only target branch. No merge, rebase, PR, or promotion into
+   `main`.
+2. No tag, no npm publish, no alpha, no consumer pilot, no GA claim.
+3. The supported value shape is exactly `{ cy?: string; test?: string }`. Do not
+   introduce `data-testid` anywhere, including docs.
+4. Do not collapse a multi-control API into a single ambiguous selector.
+5. No refs work, theme changes, visual redesign, bundle changes, export changes,
+   or new dependencies. **Named exception:** Formik work is limited to adding the
+   inherited root `data` pass-through to `FormikColorPicker`. Nothing else in
+   `src/forms/*.tsx` is touched.
+6. Do not retrofit the 37 selectorless components. That was ruled out.
+7. Do not remove `trees/rs-v5-test-selector-contract` or its branch. Cleanup
+   needs a separate explicit request.
+8. Scope ambiguity, source drift, or a failed contract is a stop-and-report
+   condition, not licence to widen the slice.
+
+## Verification
+
+Run from `packages/design-system` with the `VOLTA_FEATURE_PNPM=1` prefix:
+
+- `pnpm check` — `tsc --noEmit` plus `tsc -p tsconfig.types.json --noEmit`
+- `pnpm lint` — `eslint --max-warnings 0`. Note `eslint.config.mjs:22` globally
+  ignores `**/ui`, so the `Calendar` edit is covered by `pnpm check` and the
+  smoke test only, not by lint.
+- `pnpm format:check`
+- `pnpm build` — confirm the five new root props reach `dist/index.d.ts`
+- `pnpm build:ladle` — required, because this slice changes fifteen story files
+- `tests/smoke` plus `tests/contracts` — expect the current 470 to rise by the
+  number of added cases
+- `tests/a11y` — two separate expectations. The case count stays at 772, because
+  the total is `themes x story ids` (`tests/a11y/stories.spec.ts:121-125`) and no
+  story id is added or removed. Separately, the suite must stay green; a green
+  772 proves the story-id set is unchanged, not that the slice is a11y-neutral.
+
+## Gates before the PR is presented
+
+Per the mandatory review gates: this plan is reviewed read-only before
+implementation (done 2026-08-03; seven findings, all verified and folded in);
+each slice outcome is reviewed before the next starts; the integrated branch
+gets a maintainability gate, a bounded security gate, and an independent branch
+review after verification, before the PR is published.
+
+## Progress
+
+- 2026-08-03: Branch and worktree created at `2fc8f915`. Inventory completed and
+  verified: 0 deviant shapes, 8 components with per-element props, 37 with none,
+  `src/original` confirmed dead. Both scope rulings obtained.
+- 2026-08-03: Plan review gate run. Seven findings, all independently verified
+  against source and folded in: the `src/forms/` doc corpus was missing entirely
+  (5 in-scope files, 8 excluded), `MIGRATION.md` was dropped despite roadmap line
+  208, W2.2's placement instruction was self-contradictory and collided with
+  `dataTrigger`, `Calendar` is not popover-based, `FormikColorPicker` inherits
+  nothing, two `{...props}` spreads can silently misplace the new prop, and the
+  a11y expectation conflated case count with suite health. Story-doc scope
+  restated from 8 files to 15 files / 33 lines.

--- a/project/2026-08-03-v5-w2-selector-rollout-plan.md
+++ b/project/2026-08-03-v5-w2-selector-rollout-plan.md
@@ -320,3 +320,47 @@ review after verification, before the PR is published.
   the right home for them given those two files document no other prop in the
   README, but it means the Ladle page for those two does not advertise the new
   prop. Left as is rather than introducing a prop list those files never had.
+- 2026-08-03: mandatory maintainability gate (`$thermo-nuclear-code-quality-review`)
+  run against `098a46f8` as a separate read-only review. Verdict BLOCK, eight
+  findings, all eight verified against source before acting. Two of them
+  corrected claims recorded earlier in this file:
+  - The contract type fixtures ARE CI-gated. `package.json` defines `check` as
+    `run-s check:ts check:types`, `check:types` runs
+    `tsc -p tsconfig.types.json --noEmit`, and `.github/workflows/main.yml`
+    runs `pnpm run check`. The earlier note claiming enforcement rested on the
+    tsconfig `include` alone was wrong. What is genuinely unenforced is
+    `tests/contracts/*.spec.ts`, which no CI job executes.
+  - The root `data` prop does not mean the same thing on all five components.
+    `ColorPicker`'s selector div encloses its `Popover` and `Calendar`'s is the
+    whole widget, but on the three date pickers the div is a DOM sibling of
+    `PopoverContent`, so it does not contain the open calendar. Checked against
+    the shadcn reference via Context7: shadcn composes `PopoverTrigger` and
+    `PopoverContent` as siblings under `Popover` with no shared wrapper, so the
+    sibling structure is correct and the docs were wrong, not the DOM. Ruling:
+    match shadcn, correct `MIGRATION.md`, and pin the asymmetry with a test.
+- 2026-08-03: the dual-API deferral did not survive the gate. `Calendar`'s raw
+  `data-cy`/`data-test` props were never load-bearing — TypeScript does not
+  excess-property-check hyphenated JSX attributes on custom components, so the
+  pickers compiled without them all along. Removed; the three pickers now pass
+  `data={dataCalendar}`. `tsc` clean, and a `@ts-expect-error` in the fixture
+  now proves the raw form is rejected. The `??` fallback is gone with it.
+- 2026-08-03: introduced the canonical layer the contract was missing —
+  `src/lib/testSelectors.ts` exporting `TestSelectors` and `testAttrs()`.
+  Applied to the six files this branch already touches; the other 48 remain a
+  mechanical follow-up. The `data-text` typo fixed in W2 was possible only
+  because every render site spelled the attribute out by hand, so this removes
+  the defect class rather than one instance of it.
+- 2026-08-03: both residual `{...props}` spreads into `<Calendar>` removed.
+  `DatePickerProps` is closed and fully destructured, so its residual was
+  provably always `{}`; `DatetimePicker`'s now forwards `weekStartsOn`,
+  `showWeekNumber` and `showOutsideDays` explicitly. The trap is gone by
+  construction instead of defended against.
+- 2026-08-03: leak-guard falsifiability re-proven after the restructure, and
+  the first attempt was a false negative worth recording. Re-adding `{...props}`
+  alone does NOT leak, because `data` is destructured out — the guard only fails
+  when a spread returns AND `data` is left undestructured. Reproduced that exact
+  pair against a clean `rm -rf build` rebuild: `Expected: 1, Received: 2`.
+  Restored from backup, `diff` against the backup clean.
+- 2026-08-03: post-gate verification, all green — `pnpm check`, `pnpm lint`,
+  `pnpm format:check`, `pnpm build`, `build:ladle` clean, full Playwright suite
+  1247 passed (up from 1245: the leak guard was split into three focused tests).

--- a/project/2026-08-03-v5-w2-selector-rollout-plan.md
+++ b/project/2026-08-03-v5-w2-selector-rollout-plan.md
@@ -258,6 +258,19 @@ review after verification, before the PR is published.
 - 2026-08-03: Branch and worktree created at `2fc8f915`. Inventory completed and
   verified: 0 deviant shapes, 8 components with per-element props, 37 with none,
   `src/original` confirmed dead. Both scope rulings obtained.
+- 2026-08-03: W2.4, W2.5 and W2.6 complete. Full suite green at 1245 tests: 473
+  smoke plus contracts (three new selector cases) and 772 a11y, unchanged as
+  predicted, so adding the five components to `public-contracts--default` cost
+  no story-id waiver.
+- 2026-08-03: **`pnpm build:ladle` fails open.** A story importing a missing
+  export produced a rollup error, left the previous `build/` in place, and still
+  exited 0, so `pnpm test` ran its whole suite against stale content and
+  reported green. The three new selector tests failed only because they asserted
+  on markup the stale build did not contain; had they been weaker, the slice
+  would have looked verified while proving nothing. Anything trusting a green
+  local run must confirm `build/` actually contains the markup under test. Worth
+  a follow-up slice to make the build exit non-zero. Note `DatetimePicker.tsx`
+  has no default export; the component is `DateTimePicker`, capital T.
 - 2026-08-03: Plan review gate run. Seven findings, all independently verified
   against source and folded in: the `src/forms/` doc corpus was missing entirely
   (5 in-scope files, 8 excluded), `MIGRATION.md` was dropped despite roadmap line

--- a/project/2026-08-03-v5-w2-selector-rollout-plan.md
+++ b/project/2026-08-03-v5-w2-selector-rollout-plan.md
@@ -258,6 +258,9 @@ review after verification, before the PR is published.
 - 2026-08-03: Branch and worktree created at `2fc8f915`. Inventory completed and
   verified: 0 deviant shapes, 8 components with per-element props, 37 with none,
   `src/original` confirmed dead. Both scope rulings obtained.
+- 2026-08-03: W2.1, W2.2 and W2.3 complete in `7257ab39` (ColorPicker
+  `data-text` fix, root `data` prop on the five components, `FormikColorPicker`
+  pass-through) and `578fe1d4` (33 corrected examples across 15 story files).
 - 2026-08-03: W2.4, W2.5 and W2.6 complete. Full suite green at 1245 tests: 473
   smoke plus contracts (three new selector cases) and 772 a11y, unchanged as
   predicted, so adding the five components to `public-contracts--default` cost
@@ -279,3 +282,33 @@ review after verification, before the PR is published.
   nothing, two `{...props}` spreads can silently misplace the new prop, and the
   a11y expectation conflated case count with suite health. Story-doc scope
   restated from 8 files to 15 files / 33 lines.
+- 2026-08-03: Final integrated review gate run on `2fc8f915..74113351`. Nine
+  findings, none critical or high, all verified against source before acting.
+  **The leak/precedence guard could not fail.** `root.locator(...)` matches
+  descendants only, but `<PopoverContent>` is a *sibling* of the wrapper that
+  carries the root selector, and the popover was still closed at that line; the
+  second assertion was a tautology (an element found by `data-cy=X` cannot also
+  have `data-cy=Y`). The DatePicker instance could never prove the point anyway,
+  because its own `dataCalendar` masks a leak through the `??` fallback. Rewritten
+  against `DatetimePicker`, the one unmasked vector: it sets `data`, sets no
+  `dataCalendar`, and does spread `{...props}` into `<Calendar>`. Falsifiability
+  confirmed empirically — routing its root selector through `props.data` makes the
+  count 2 and the test red; restored and green.
+- 2026-08-03: Same gate, documentation findings. `MIGRATION.md` claimed only the
+  deprecated `Formik*` stories were stale (the per-story prop reference lists are
+  too), presented an eight-item per-element list as exhaustive when four props
+  were missing, and stated a "per-element prop wins" precedence that has no
+  instance in the shipped API — no component renders a root `data` and a
+  per-element prop on the same element. Corrected, and the real rule documented:
+  the root selector is never inherited by sub-elements. The new root `data` prop
+  was also absent from the entire story corpus. Added to all five, and the
+  adjacent pre-v5 `Record<string, string>` type lines in those same five files
+  corrected with it, since a correctly typed `data` line beside them would have
+  left two contradicting conventions in one list. The equivalent stale lines in
+  `Modal`, `Header`, `Navigation` and others remain; `MIGRATION.md` now says so
+  rather than claiming the corpus is clean.
+- 2026-08-03: Ladle's production build drops `.stories.mdx` prose entirely — it
+  appears in neither `build/assets/` nor `meta.json`. Pre-existing behaviour, not
+  a branch regression (prose never touched by this branch is absent too), but it
+  means story documentation cannot be verified through the built bundle and the
+  freshness check above does not cover it.


### PR DESCRIPTION
## What This Adds

This is Stack B layer W2 for the `v5` release branch, the second half of the
test-selector work. W1 fixed the contract on `Table`, `Workflow` and
`WorkflowProgress`. W2 finishes the five date and colour composites, then
collapses the whole convention onto one exported type so no call site retypes
it.

- The five remaining composites gain a root `data` selector: `Calendar`,
  `ColorPicker`, `DatePicker`, `DateRangePicker` and `DatetimePicker`.
- `ColorPicker`'s hex input emitted `data-text` instead of `data-test`. The
  value was typed correctly and never reached the DOM. Fixed, with a
  regression test.
- Adds `TestSelectors` and `testAttrs()` under `src/lib/`, exported from both
  `index.ts` and `primitives.ts`, and adopts them in the six files this branch
  already touches.
- `Calendar`'s second, undeclared selector API is gone: it accepted raw
  `data-cy` / `data-test` props alongside the contract shape.
- Corrects 33 selector examples across the story docs, which still showed
  `data-testid` and raw-attribute forms that v5 does not accept.
- Adds five Playwright cases and a compile-time fixture covering the root
  props, the scope asymmetry, and the `data-text` regression.

## How It Works

The selector value shape is exactly `{ cy?: string; test?: string }`, rendered
as `data-cy` and `data-test`. That shape now has one definition:

```tsx
import type { TestSelectors } from '@uzh-bf/design-system'
```

`testAttrs()` emits only the keys that carry a value. That matters because
several call sites spread it after `{...props}`, and a helper that emitted both
keys unconditionally would blank an attribute a neighbouring spread supplied.

`DatePicker` and `DatetimePicker` no longer forward a residual `{...props}`
into `<Calendar>`. `DatePickerProps` is a closed interface whose members are
all destructured, so its rest object was provably empty; `DateTimePickerProps`
picks four `DayPickerProps` members, which are now forwarded by name.

## Important Details

Two breaking changes, both on components whose selector props already used the
contract shape, so most call sites are unaffected.

**`Calendar` no longer declares raw attribute props.** Be precise about what
this removes. The prop *declarations* are gone, so an object-literal call site
stops compiling. A JSX call site does not:

```tsx
<Calendar mode="single" data-cy="x" />  // still compiles, still reaches the DOM
```

TypeScript exempts hyphenated attribute names from excess-property checking on
custom components, and DayPicker passes unknown props through. That form is
undocumented rather than rejected. The declared `data` prop is spread last, so
it wins when both are present, but nothing asserts that and no in-repo caller
does it.

**The root selector marks the trigger area, not the whole component.** On the
three date pickers, `PopoverTrigger` and `PopoverContent` are siblings under
`Popover` rather than nested in a shared wrapper, matching shadcn's
composition. So the root selector does not enclose the open popover:

```js
// does NOT match — the calendar is not inside the root
cy.get('[data-cy="my-picker"]').find('[role="dialog"]')
```

Use `dataCalendar` to address the open calendar. `ColorPicker` is the
counter-example: its root div does wrap its own `Popover`, so the identical
query works there. Same prop name, two scopes. A test pins both so the
asymmetry cannot drift out of the docs.

## Branch Coverage

All 11 commits from `2fc8f915`:

| Commit | Content |
| --- | --- |
| `1d40e2a6` | W2 execution plan |
| `7257ab39` | Five root `data` props, `data-text` fix (breaking) |
| `578fe1d4` | 33 corrected selector examples in story docs |
| `28431e24` | Smoke cases, type fixtures, `Calendar` precedence |
| `74113351` | MIGRATION and roadmap alignment |
| `39fc5ea9` | Falsifiable calendar leak guard |
| `337fd808` | Corrected selector claims in MIGRATION and stories |
| `098a46f8` | Corrected the Ladle story-prose finding in the plan |
| `911de6bf` | Canonical layer, dual-API removal (breaking) |
| `e6f2d499` | Made the removal claims match the code |
| `035b9236` | Dropped an unasserted precedence claim from the fixture |

The last three exist because two maintainability-gate rounds found that earlier
commits on this branch described themselves inaccurately. They are corrections
to this branch's own work, not new scope.

## Review Focus

- `testAttrs()`'s omit-unset-keys behaviour and the spread position at each of
  its call sites. Spread order is load-bearing here.
- The `DatePicker` / `DatetimePicker` passthrough removal. The claim is that
  the removed rest objects were empty or fully replaced by named forwards.
- Whether the trigger-area scope is the contract you want, given it is
  inherited from shadcn's composition rather than chosen.

## Known Gaps, Recorded Not Fixed

- The mechanical `TestSelectors` adoption across the remaining ~49 files that
  still inline `{ cy?: string; test?: string }`. Scoped out deliberately: this
  branch adopts the type in the six files it already modifies. The follow-up is
  a type-only sweep with no behaviour change.
- `src/ui/popover.tsx` omits shadcn's `PopoverPrimitive.Portal`, which is why
  content renders as an inline sibling. Restoring it would move every popover's
  DOM position and needs its own visual-regression run.
- No lint rule forbids inline `{ cy, test }` literals, so the canonical type is
  convention rather than enforcement until the sweep lands.

## Verification

Current head (`035b9236`), all re-run locally against this exact commit:

- `pnpm check` (TypeScript, including the `tsconfig.types.json` contract
  fixture), `pnpm lint`, `pnpm format:check`, `pnpm build` -> all exit 0.
- `pnpm build:ladle` -> exit 0.
- Full Playwright suite -> 1249 passed, 0 failed.
- Test enumeration on this head: 1249 total, of which 772 a11y and 469 smoke.
  The a11y figure is unchanged from W1 because this branch adds props to
  existing story instances rather than new stories; it is enumerated here
  rather than carried over.
- `TestSelectors` is present and exported in the built declarations, so the
  import example above works for consumers: `export declare type TestSelectors`
  appears once, un-renamed, in both `dist/index.d.ts` and
  `dist/primitives.d.ts`.

The calendar leak guard is falsifiable but narrower than it looks. Re-adding a
`{...props}` spread into `<Calendar>` alone does not trip it, because `data` is
destructured out of the rest. It fails only on the pair: a rest spread reaching
`<Calendar>` and `data` left undestructured. That pair was reproduced against a
clean rebuild and produced `Expected: 1, Received: 2`.

Not run:

- Visual regression. The VRT gate is a later roadmap item and no baseline
  exists for the contract story yet. This branch changes no styles, only
  attributes and prop plumbing.

## Security / Privacy

- Review: bounded code-level security review over `2fc8f915..035b9236`. This
  supersedes an earlier pass that covered only the first five commits.
- Result: no high-confidence vulnerabilities, risk assessed Low. The change
  adds optional string attributes to rendered DOM, renames props, and removes
  two prop passthroughs. No risky sinks, dependency changes, or workflow
  changes appear in the range.
- Sensitive data: none. No secrets, credentials, or private payloads.

## Blocking Before Merge

- [x] CI green on this head. All required checks pass on `035b9236`:
  [run 30811430441](https://github.com/uzh-bf/design-system/actions/runs/30811430441)
  covers types, lint, formatting, test, build-and-publish and all four a11y
  shards; [run 30811430376](https://github.com/uzh-bf/design-system/actions/runs/30811430376)
  covers build, with `deploy` skipped as expected on a non-`v5` head. Greptile
  reviewed with no findings. The Ladle preview deployed to Vercel.

  The `Build and Publish` job name is misleading on a PR head: only its
  checkout, setup and `Build` steps ran, no publish step. `npm dist-tags` for
  the package are unchanged at `latest` 4.1.6 and `alpha` 5.0.0-alpha.1,
  checked after the run completed.

## Follow-Up After Merge

- [ ] The mechanical `TestSelectors` sweep across the remaining ~49 files.
- [ ] Restore `PopoverPrimitive.Portal` in `src/ui/popover.tsx` behind its own
  VRT run, which would also make the root-selector scope uniform.
- [ ] W3 onward: bundle, VRT and release gates, per the post-A3 roadmap. npm
  publication stays held.
